### PR TITLE
Move notification plugin into management section on left navigation menu

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const LICENSE_HEADER = `
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+`
+
+module.exports = {
+  root: true,
+  extends: ['@elastic/eslint-config-kibana', 'plugin:@elastic/eui/recommended'],
+  rules: {
+    // "@osd/eslint/require-license-header": "off"
+  },
+  overrides: [
+    {
+      files: ['**/*.{js,ts,tsx}'],
+      rules: {
+        '@osd/eslint/require-license-header': [
+          'error',
+          {
+            licenses: [ LICENSE_HEADER ],
+          },
+        ],
+        "no-console": 0
+      }
+    }
+  ],
+};

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -7,7 +7,8 @@
     "data"
   ],
   "optionalPlugins": [
-    "share"
+    "share",
+    "managementOverview"
   ],
   "server": true,
   "ui": true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "osd": "node ../../scripts/osd",
     "opensearch": "node ../../scripts/opensearch",
-    "lint": "eslint .",
+    "lint": "node ../../scripts/eslint . && node ../../scripts/stylelint",
     "start": "yarn plugin_helpers start",
     "build": "yarn plugin_helpers build",
     "test:jest": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -21,7 +21,7 @@ import { CreateSESSender } from '../Emails/CreateSESSender';
 import { EmailGroups } from '../Emails/EmailGroups';
 import { EmailSenders } from '../Emails/EmailSenders';
 
-export enum Navigation {
+enum Navigation {
   Notifications = 'Notifications',
   Channels = 'Channels',
   EmailSenders = 'Email senders',

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -21,7 +21,7 @@ import { CreateSESSender } from '../Emails/CreateSESSender';
 import { EmailGroups } from '../Emails/EmailGroups';
 import { EmailSenders } from '../Emails/EmailSenders';
 
-enum Navigation {
+export enum Navigation {
   Notifications = 'Notifications',
   Channels = 'Channels',
   EmailSenders = 'Email senders',

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { i18n } from '@osd/i18n';
 import {
   AppMountParameters,
   CoreSetup,
@@ -13,16 +14,9 @@ import {
 import {
   notificationsDashboardsPluginSetup,
   notificationsDashboardsPluginStart,
-  AppPluginStartDependencies,
+  NotificationsDashboardsSetupDeps,
 } from './types';
 import { PLUGIN_NAME } from '../common';
-import { Navigation } from "./pages/Main/Main";
-import { ROUTES } from "./utils/constants";
-import { ManagementOverViewPluginSetup } from "../../../src/plugins/management_overview/public";
-
-interface NotificationsDashboardsSetupDeps {
-  managementOverview?: ManagementOverViewPluginSetup;
-}
 
 export class notificationsDashboardsPlugin
   implements
@@ -30,11 +24,18 @@ export class notificationsDashboardsPlugin
       notificationsDashboardsPluginSetup,
       notificationsDashboardsPluginStart
     > {
-  public setup(core: CoreSetup, { managementOverview }: NotificationsDashboardsSetupDeps): notificationsDashboardsPluginSetup {
+  private title = i18n.translate('notification.notificationTitle', {
+    defaultMessage: 'Notifications',
+  });
+
+  public setup(
+    core: CoreSetup,
+    { managementOverview }: NotificationsDashboardsSetupDeps
+  ): notificationsDashboardsPluginSetup {
     // Register an application into the side navigation menu
     core.application.register({
       id: PLUGIN_NAME,
-      title: 'Notifications',
+      title: this.title,
       category: DEFAULT_APP_CATEGORIES.management,
       order: 9060,
       async mount(params: AppMountParameters) {
@@ -50,25 +51,12 @@ export class notificationsDashboardsPlugin
     if (managementOverview) {
       managementOverview.register({
         id: PLUGIN_NAME,
-        title: 'Notifications',
+        title: this.title,
         order: 9060,
-        pages: [
-          {
-            title: Navigation.Channels,
-            url: `#${ROUTES.CHANNELS}`,
-            order: 100
-          },
-          {
-            title: Navigation.EmailSenders,
-            url: `#${ROUTES.EMAIL_SENDERS}`,
-            order: 200
-          },
-          {
-            title: Navigation.EmailGroups,
-            url: `#${ROUTES.EMAIL_GROUPS}`,
-            order: 300
-          },
-        ]
+        description: i18n.translate('notification.notificationDescription', {
+          defaultMessage:
+            'Connect with your communication service to receive notifications from supported OpenSearch plugins.',
+        }),
       });
     }
 

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -16,9 +16,9 @@ import {
   AppPluginStartDependencies,
 } from './types';
 import { PLUGIN_NAME } from '../common';
-import {Navigation} from "./pages/Main/Main";
-import {ROUTES} from "./utils/constants";
-import {ManagementOverViewPluginSetup} from "../../../src/plugins/management_overview/public";
+import { Navigation } from "./pages/Main/Main";
+import { ROUTES } from "./utils/constants";
+import { ManagementOverViewPluginSetup } from "../../../src/plugins/management_overview/public";
 
 interface NotificationsDashboardsSetupDeps {
   managementOverview?: ManagementOverViewPluginSetup;
@@ -30,7 +30,7 @@ export class notificationsDashboardsPlugin
       notificationsDashboardsPluginSetup,
       notificationsDashboardsPluginStart
     > {
-  public setup(core: CoreSetup, {managementOverview}: NotificationsDashboardsSetupDeps): notificationsDashboardsPluginSetup {
+  public setup(core: CoreSetup, { managementOverview }: NotificationsDashboardsSetupDeps): notificationsDashboardsPluginSetup {
     // Register an application into the side navigation menu
     core.application.register({
       id: PLUGIN_NAME,

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -7,6 +7,7 @@ import {
   AppMountParameters,
   CoreSetup,
   CoreStart,
+  DEFAULT_APP_CATEGORIES,
   Plugin,
 } from '../../../src/core/public';
 import {
@@ -15,6 +16,13 @@ import {
   AppPluginStartDependencies,
 } from './types';
 import { PLUGIN_NAME } from '../common';
+import {Navigation} from "./pages/Main/Main";
+import {ROUTES} from "./utils/constants";
+import {ManagementOverViewPluginSetup} from "../../../src/plugins/management_overview/public";
+
+interface NotificationsDashboardsSetupDeps {
+  managementOverview?: ManagementOverViewPluginSetup;
+}
 
 export class notificationsDashboardsPlugin
   implements
@@ -22,17 +30,13 @@ export class notificationsDashboardsPlugin
       notificationsDashboardsPluginSetup,
       notificationsDashboardsPluginStart
     > {
-  public setup(core: CoreSetup): notificationsDashboardsPluginSetup {
+  public setup(core: CoreSetup, {managementOverview}: NotificationsDashboardsSetupDeps): notificationsDashboardsPluginSetup {
     // Register an application into the side navigation menu
     core.application.register({
       id: PLUGIN_NAME,
       title: 'Notifications',
-      category: {
-        id: 'opensearch',
-        label: 'OpenSearch Plugins',
-        order: 2000,
-      },
-      order: 6000,
+      category: DEFAULT_APP_CATEGORIES.management,
+      order: 9060,
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application');
@@ -42,6 +46,31 @@ export class notificationsDashboardsPlugin
         return renderApp(coreStart, params);
       },
     });
+
+    if (managementOverview) {
+      managementOverview.register({
+        id: PLUGIN_NAME,
+        title: 'Notifications',
+        order: 9060,
+        pages: [
+          {
+            title: Navigation.Channels,
+            url: `#${ROUTES.CHANNELS}`,
+            order: 100
+          },
+          {
+            title: Navigation.EmailSenders,
+            url: `#${ROUTES.EMAIL_SENDERS}`,
+            order: 200
+          },
+          {
+            title: Navigation.EmailGroups,
+            url: `#${ROUTES.EMAIL_GROUPS}`,
+            order: 300
+          },
+        ]
+      });
+    }
 
     // Return methods that should be available to other plugins
     return {};

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -55,7 +55,7 @@ export class notificationsDashboardsPlugin
         order: 9060,
         description: i18n.translate('notification.notificationDescription', {
           defaultMessage:
-            'Connect with your communication service to receive notifications from supported OpenSearch plugins.',
+            'Connect with your communication services to receive notifications from supported OpenSearch plugins.',
         }),
       });
     }

--- a/public/types.ts
+++ b/public/types.ts
@@ -4,6 +4,7 @@
  */
 
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+import { ManagementOverViewPluginSetup } from "../../../src/plugins/management_overview/public";
 
 export interface notificationsDashboardsPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -11,4 +12,8 @@ export interface notificationsDashboardsPluginStart {}
 
 export interface AppPluginStartDependencies {
   navigation: NavigationPublicPluginStart;
+}
+
+export interface NotificationsDashboardsSetupDeps {
+  managementOverview?: ManagementOverViewPluginSetup;
 }


### PR DESCRIPTION
### Description
Move notification from plugins section into Management section and register which pages does the plugin have to show in management overview page

### Issues Resolved
#48 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
