### PR TITLE
Improve wording for TLS-related options

### DIFF
--- a/.cypress/integration/email_senders_and_groups.spec.js
+++ b/.cypress/integration/email_senders_and_groups.spec.js
@@ -67,7 +67,7 @@ describe('Test create email senders', () => {
       force: true,
     });
     cy.wait(delay);
-    cy.get('.euiContextMenuItem__text').contains('TLS').click({ force: true });
+    cy.get('.euiContextMenuItem__text').contains('STARTTLS').click({ force: true });
     cy.wait(delay);
 
     cy.get('.euiButton__text').contains('Create').click({ force: true });

--- a/public/pages/Emails/__tests__/SendersTableControls.test.tsx
+++ b/public/pages/Emails/__tests__/SendersTableControls.test.tsx
@@ -56,7 +56,7 @@ describe('<SendersTableControls /> spec', () => {
       </MainContext.Provider>
     );
     fireEvent.click(utils.getByText('Encryption method'));
-    fireEvent.click(utils.getByText('TLS'));
+    fireEvent.click(utils.getByText('STARTTLS'));
     fireEvent.click(utils.getByText('None'));
     expect(onFiltersChange).toBeCalledWith({ encryptionMethod: ["start_tls", "none"] });
   });

--- a/public/pages/Emails/components/forms/CreateSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSenderForm.tsx
@@ -147,7 +147,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
         style={{ maxWidth: '650px' }}
         helpText={
           <div>
-            SSL or TLS is recommended for security. To use either one, you must
+            SSL/TLS or STARTTLS is recommended for security. To use either one, you must
             enter each sender account's credentials to the OpenSearch
             keystore using the CLI.{' '}
             <EuiLink

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -74,8 +74,8 @@ export const CHANNEL_TYPE = Object.freeze({
 };
 
 export const ENCRYPTION_TYPE = Object.freeze({
-  ssl: 'SSL',
-  start_tls: 'TLS',
+  ssl: 'SSL/TLS',
+  start_tls: 'STARTTLS',
   none: 'None',
 });
 


### PR DESCRIPTION
When configuring a SMTP sender, the user is prompted for an "Encryption method" and given a drop-down list to choose from.  The list currently contain "SSL", "TLS" and "None" which is a bit confusing given that TLS is built on deprecated SSL and both refer to the same thing.

In this list, "SSL" actually mean TLS, and "TLS" actually mean StartTLS (aka Opportunistic TLS).

Adjust wording to wake this more obvious.  The new wording match the one used in Thunderbird when configuring connection security.
