### PR TITLE
Replaced wrongly formatted mock Slack URLs with properly formatted mock Slack URLs

### DIFF
--- a/.cypress/fixtures/test_slack_channel.json
+++ b/.cypress/fixtures/test_slack_channel.json
@@ -5,7 +5,7 @@
     "config_type": "slack",
     "is_enabled": true,
     "slack": {
-      "url": "https://sample-slack-webhook"
+      "url": "https://hooks.slack.com/services/A123456/B1234567/A1B2C3D4E5F6G7H8I9J0K1L2"
     }
   }
 }

--- a/.cypress/integration/channels.spec.js
+++ b/.cypress/integration/channels.spec.js
@@ -35,7 +35,7 @@ describe('Test create channels', () => {
 
     cy.get('[placeholder="Enter channel name"]').type('Test slack channel');
     cy.get('[data-test-subj="create-channel-slack-webhook-input"]').type(
-      'https://sample-slack-webhook'
+      'https://hooks.slack.com/services/A123456/B1234567/A1B2C3D4E5F6G7H8I9J0K1L2'
     );
     cy.wait(delay);
     cy.get('[data-test-subj="create-channel-send-test-message-button"]').click({

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelSettingsDetails.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelSettingsDetails.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`<ChannelSettingsDetails /> spec renders Slack channel 1`] = `
         <dd
           class="euiDescriptionList__description"
         >
-          https://chimehook
+          https://hooks.slack.com/services/A123456/B1234567/A1B2C3D4E5F6G7H8I9J0K1L2
         </dd>
       </dl>
     </div>

--- a/test/mocks/mockData.ts
+++ b/test/mocks/mockData.ts
@@ -29,7 +29,7 @@ const mockSlack: ChannelItemType = {
   config_type: 'slack',
   is_enabled: false,
   slack: {
-    url: 'https://chimehook',
+    url: 'https://hooks.slack.com/services/A123456/B1234567/A1B2C3D4E5F6G7H8I9J0K1L2',
   },
   config_id: 'test-slack',
   created_time_ms: 1622670451891,


### PR DESCRIPTION
Integrates with [#814](https://github.com/opensearch-project/notifications/pull/814) in the backend notifications repo

### Description
Replaces mock Slack URLs (which wouldn't pass validation tests) with mock Slack URLs (which will pass validation tests)

### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
