### PR TITLE
Update to latest babel package name

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,7 @@
   "plugins": [
     "@babel/plugin-transform-modules-commonjs",
     ["@babel/plugin-transform-runtime", { "regenerator": true }],
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread"
+    "@babel/plugin-transform-class-properties",
+    "@babel/plugin-transform-object-rest-spread"
   ]
 } 


### PR DESCRIPTION
### Description
Update to latest babel package name  due to 
> This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
