### PR TITLE
Feat: remove opensearch.log introduced from #145

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -82,7 +82,7 @@ jobs:
               brew install coreutils
           fi
           cd notifications/notifications
-          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} -x integTest -x jacocoTestReport | tee -a opensearch.log &
+          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} -x integTest -x jacocoTestReport &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
         shell: bash
         env:
@@ -201,12 +201,6 @@ jobs:
         with:
           name: cypress-screenshots-${{ matrix.os }}
           path: OpenSearch-Dashboards/plugins/dashboards-notifications/.cypress/screenshots
-
-      - uses: actions/upload-artifact@v1
-        if: always()
-        with:
-          name: opensearch-logs-${{ matrix.os }}
-          path: notifications/notifications/opensearch.log
 
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v1


### PR DESCRIPTION
### Description
In Windows, there is a file lock which makes action/upload-artifact unable to upload opensearch.log.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
