### PR TITLE
Moved enrichment of server features to server side

### DIFF
--- a/public/services/NotificationService.ts
+++ b/public/services/NotificationService.ts
@@ -4,7 +4,6 @@
  */
 
 import { SortDirection } from '@elastic/eui';
-import _ from 'lodash';
 import { HttpFetchQuery, HttpSetup } from '../../../../src/core/public';
 import { NODE_API } from '../../common';
 import {
@@ -14,7 +13,6 @@ import {
   SenderType,
   SESSenderItemType,
 } from '../../models/interfaces';
-import { CHANNEL_TYPE } from '../utils/constants';
 import {
   configListToChannels,
   configListToRecipientGroups,
@@ -215,21 +213,8 @@ export default class NotificationService {
       const response = await this.httpClient.get(
         NODE_API.GET_AVAILABLE_FEATURES
       );
-      const config_type_list = response.allowed_config_type_list as Array<
-        keyof typeof CHANNEL_TYPE
-      >;
-      const channelTypes: Partial<typeof CHANNEL_TYPE> = {};
-      for (let i = 0; i < config_type_list.length; i++) {
-        const channel = config_type_list[i];
-        if (!CHANNEL_TYPE[channel]) continue;
-        channelTypes[channel] = CHANNEL_TYPE[channel];
-      }
-      return {
-        availableChannels: channelTypes,
-        availableConfigTypes: config_type_list as string[],
-        tooltipSupport:
-          _.get(response, ['plugin_features', 'tooltip_support']) === 'true',
-      };
+      
+      return response;
     } catch (error) {
       console.error('error fetching available features', error);
       return null;

--- a/server/routes/configRoutes.ts
+++ b/server/routes/configRoutes.ts
@@ -10,6 +10,8 @@ import {
 } from '../../../../src/core/server';
 import { NODE_API } from '../../common';
 import { joinRequestParams } from '../utils/helper';
+import _ from 'lodash';
+import { CHANNEL_TYPE } from '../../public/utils/constants';
 
 export function configRoutes(router: IRouter) {
   router.get(
@@ -210,7 +212,22 @@ export function configRoutes(router: IRouter) {
         const resp = await client.callAsCurrentUser(
           'notifications.getServerFeatures'
         );
-        return response.ok({ body: resp });
+        const config_type_list = resp.allowed_config_type_list as Array<
+          keyof typeof CHANNEL_TYPE
+        >;
+        const channelTypes: Partial<typeof CHANNEL_TYPE> = {};
+        for (let i = 0; i < config_type_list.length; i++) {
+          const channel = config_type_list[i];
+          if (!CHANNEL_TYPE[channel]) continue;
+          channelTypes[channel] = CHANNEL_TYPE[channel];
+        }
+        const availableFeature = {
+          availableChannels: channelTypes,
+          availableConfigTypes: config_type_list as string[],
+          tooltipSupport:
+            _.get(response, ['plugin_features', 'tooltip_support']) === 'true',
+        };
+        return response.ok({ body: availableFeature });
       } catch (error) {
         return response.custom({
           statusCode: error.statusCode || 500,

--- a/server/routes/configRoutes.ts
+++ b/server/routes/configRoutes.ts
@@ -216,11 +216,13 @@ export function configRoutes(router: IRouter) {
           keyof typeof CHANNEL_TYPE
         >;
         const channelTypes: Partial<typeof CHANNEL_TYPE> = {};
-        for (let i = 0; i < config_type_list.length; i++) {
-          const channel = config_type_list[i];
-          if (!CHANNEL_TYPE[channel]) continue;
-          channelTypes[channel] = CHANNEL_TYPE[channel];
+        
+        for (let channel of config_type_list) {
+          if (CHANNEL_TYPE[channel]) {
+            channelTypes[channel] = CHANNEL_TYPE[channel]
+          }
         }
+
         const availableFeature = {
           availableChannels: channelTypes,
           availableConfigTypes: config_type_list as string[],


### PR DESCRIPTION
### Description
In notifications plugin, the response from `/_plugins/_notifications/features` is used to derive the available channels. Since, alerting also requires this information and uses the routes setup in the notification dashboards server to fetch the server features, this PR moves the logic of deriving channels to the server itself. This way we keep single source of truth for the available channels and alerting would the updates for free in future.

### Issues Resolved
Plays role in fixing https://github.com/opensearch-project/alerting-dashboards-plugin/issues/795

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
