### PR TITLE
handle error state properly when dataSource switches

### DIFF
--- a/public/components/MDSEnabledComponent/MDSEnabledComponent.tsx
+++ b/public/components/MDSEnabledComponent/MDSEnabledComponent.tsx
@@ -31,4 +31,8 @@ export function isDataSourceChanged(prevProps, currentProps) {
   return false;
 }
 
+export function isDataSourceError(error) {
+  return (error.body && error.body.message && error.body.message.includes("Data Source Error"));
+}
+
 

--- a/public/pages/Channels/Channels.tsx
+++ b/public/pages/Channels/Channels.tsx
@@ -161,8 +161,7 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
       );
       this.setState({ items: channels.items, total: channels.total });
     } catch (error) {
-      if(isDataSourceError(error))
-      {
+      if (isDataSourceError(error)) {
         this.setState({ items: [], total: 0 });
       }
       this.context.notifications.toasts.addDanger(

--- a/public/pages/Channels/Channels.tsx
+++ b/public/pages/Channels/Channels.tsx
@@ -39,7 +39,10 @@ import { ChannelActions } from './components/ChannelActions';
 import { ChannelControls } from './components/ChannelControls';
 import { ChannelFiltersType } from './types';
 import { DataSourceMenuProperties } from '../../services/DataSourceMenuContext';
-import MDSEnabledComponent, { isDataSourceChanged } from '../../components/MDSEnabledComponent/MDSEnabledComponent';
+import MDSEnabledComponent, {
+  isDataSourceChanged,
+  isDataSourceError,
+} from '../../components/MDSEnabledComponent/MDSEnabledComponent';
 
 interface ChannelsProps extends RouteComponentProps, DataSourceMenuProperties {
   notificationService: NotificationService;
@@ -158,6 +161,10 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
       );
       this.setState({ items: channels.items, total: channels.total });
     } catch (error) {
+      if(isDataSourceError(error))
+      {
+        this.setState({ items: [], total: 0 });
+      }
       this.context.notifications.toasts.addDanger(
         getErrorMessage(error, 'There was a problem loading channels.')
       );

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -169,8 +169,7 @@ export class RecipientGroupsTable extends Component<
         total: recipientGroups.total,
       });
     } catch (error) {
-      if(isDataSourceError(error))
-      {
+      if (isDataSourceError(error)) {
         this.setState({ items: [], total: 0 });
       }
       this.props.coreContext.notifications.toasts.addDanger(

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -34,7 +34,10 @@ import { getErrorMessage } from '../../../../utils/helpers';
 import { DetailsListModal } from '../../../Channels/components/modals/DetailsListModal';
 import { DEFAULT_PAGE_SIZE_OPTIONS } from '../../../Notifications/utils/constants';
 import { DeleteRecipientGroupModal } from '../modals/DeleteRecipientGroupModal';
-import { isDataSourceChanged } from '../../../../components/MDSEnabledComponent/MDSEnabledComponent';
+import {
+  isDataSourceError,
+  isDataSourceChanged,
+} from '../../../../components/MDSEnabledComponent/MDSEnabledComponent';
 
 interface RecipientGroupsTableProps {
   coreContext: CoreStart;
@@ -166,6 +169,10 @@ export class RecipientGroupsTable extends Component<
         total: recipientGroups.total,
       });
     } catch (error) {
+      if(isDataSourceError(error))
+      {
+        this.setState({ items: [], total: 0 });
+      }
       this.props.coreContext.notifications.toasts.addDanger(
         getErrorMessage(error, 'There was a problem loading recipient groups.')
       );

--- a/public/pages/Emails/components/tables/SESSendersTable.tsx
+++ b/public/pages/Emails/components/tables/SESSendersTable.tsx
@@ -133,8 +133,7 @@ export class SESSendersTable extends Component<
       );
       this.setState({ items: senders.items, total: senders.total });
     } catch (error) {
-      if(isDataSourceError(error))
-      {
+      if (isDataSourceError(error)) {
         this.setState({ items: [], total: 0 });
       }
       this.props.coreContext.notifications.toasts.addDanger(

--- a/public/pages/Emails/components/tables/SESSendersTable.tsx
+++ b/public/pages/Emails/components/tables/SESSendersTable.tsx
@@ -32,7 +32,10 @@ import { ROUTES } from '../../../../utils/constants';
 import { getErrorMessage } from '../../../../utils/helpers';
 import { DEFAULT_PAGE_SIZE_OPTIONS } from '../../../Notifications/utils/constants';
 import { DeleteSenderModal } from '../modals/DeleteSenderModal';
-import { isDataSourceChanged } from '../../../../components/MDSEnabledComponent/MDSEnabledComponent';
+import {
+  isDataSourceError,
+  isDataSourceChanged,
+} from '../../../../components/MDSEnabledComponent/MDSEnabledComponent';
 
 interface SESSendersTableProps {
   coreContext: CoreStart;
@@ -130,6 +133,10 @@ export class SESSendersTable extends Component<
       );
       this.setState({ items: senders.items, total: senders.total });
     } catch (error) {
+      if(isDataSourceError(error))
+      {
+        this.setState({ items: [], total: 0 });
+      }
       this.props.coreContext.notifications.toasts.addDanger(
         getErrorMessage(error, 'There was a problem loading SES senders.')
       );

--- a/public/pages/Emails/components/tables/SendersTable.tsx
+++ b/public/pages/Emails/components/tables/SendersTable.tsx
@@ -32,7 +32,10 @@ import {
   SendersTableControls,
   SendersTableControlsFilterType,
 } from './SendersTableControls';
-import { isDataSourceChanged } from '../../../../components/MDSEnabledComponent/MDSEnabledComponent';
+import {
+  isDataSourceError,
+  isDataSourceChanged,
+} from '../../../../components/MDSEnabledComponent/MDSEnabledComponent';
 
 interface SendersTableProps {
   coreContext: CoreStart;
@@ -151,6 +154,10 @@ export class SendersTable extends Component<
       );
       this.setState({ items: senders.items, total: senders.total });
     } catch (error) {
+      if(isDataSourceError(error))
+      {
+        this.setState({ items: [], total: 0 });
+      }
       this.props.coreContext.notifications.toasts.addDanger(
         getErrorMessage(error, 'There was a problem loading SMTP senders.')
       );

--- a/public/pages/Emails/components/tables/SendersTable.tsx
+++ b/public/pages/Emails/components/tables/SendersTable.tsx
@@ -154,8 +154,7 @@ export class SendersTable extends Component<
       );
       this.setState({ items: senders.items, total: senders.total });
     } catch (error) {
-      if(isDataSourceError(error))
-      {
+      if (isDataSourceError(error)) {
         this.setState({ items: [], total: 0 });
       }
       this.props.coreContext.notifications.toasts.addDanger(


### PR DESCRIPTION
### Description
* This will fix the error when dataSource is switched from a valid dataSource to invalid dataSource i.e when API returns "Data Source Error", the channels/emails list will be empty

### Issues Resolved

#### Testing


https://github.com/opensearch-project/dashboards-notifications/assets/69919272/24f87b67-aaf3-437a-abcb-b75ae6cf7d75



### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
