### PR TITLE
side navigation changes for notifications

### DIFF
--- a/public/application.tsx
+++ b/public/application.tsx
@@ -9,8 +9,6 @@ import { HashRouter as Router, Route } from 'react-router-dom';
 import { AppMountParameters, CoreStart } from '../../../src/core/public';
 import { CoreServicesContext } from './components/coreServices';
 import Main from './pages/Main';
-import { NotificationService } from './services';
-import { ServicesContext } from './services/services';
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 import { AppPluginStartDependencies } from "./types";
 
@@ -19,6 +17,7 @@ export const renderApp = (
   params: AppMountParameters,
   dataSourceManagement: DataSourceManagementPluginSetup,
   pluginStartDependencies: AppPluginStartDependencies,
+  defaultRoute?: string,
 ) => {
 
   ReactDOM.render(
@@ -31,6 +30,7 @@ export const renderApp = (
                 multiDataSourceEnabled={!!pluginStartDependencies.dataSource}
                 dataSourceManagement={dataSourceManagement}
                 http={coreStart.http} // Pass http as a prop
+                defaultRoute={defaultRoute}
               />
             </CoreServicesContext.Provider>
         )}

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -341,7 +341,7 @@ export default class Main extends Component<MainProps, MainState> {
                                   pathname !== ROUTES.CREATE_RECIPIENT_GROUP &&
                                   !pathname.startsWith(ROUTES.EDIT_RECIPIENT_GROUP) &&
                                   // Conditionally render sidebar based on the feature flag
-                                  !core.chrome.navGroup.getNavGroupEnabled() && (
+                                  !core.chrome?.navGroup?.getNavGroupEnabled() && (
                                     <EuiPageSideBar style={{ minWidth: 155 }}>
                                       <EuiSideNav
                                         style={{ width: 155 }}
@@ -444,7 +444,7 @@ export default class Main extends Component<MainProps, MainState> {
                                         <CreateRecipientGroup {...props} edit={true} />
                                       )}
                                     />
-                                    <Redirect from="/" to={core.chrome.navGroup.getNavGroupEnabled() ? this.props.defaultRoute : ROUTES.CHANNELS} />
+                                    <Redirect from="/" to={core.chrome?.navGroup?.getNavGroupEnabled() ? this.props.defaultRoute : ROUTES.CHANNELS} />
                                   </Switch>
                                 </EuiPageBody></>
                             )}

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -51,6 +51,7 @@ interface MainProps extends RouteComponentProps {
   setActionMenu: (menuMount: MountPoint | undefined) => void;
   multiDataSourceEnabled: boolean;
   dataSourceManagement: DataSourceManagementPluginSetup;
+  defaultRoute?: string;
 }
 
 export interface MainState extends Pick<DataSourceMenuProperties, "dataSourceId" | "dataSourceLabel"> {
@@ -106,7 +107,7 @@ export default class Main extends Component<MainProps, MainState> {
     }
   }
 
-  async setServerFeatures() : Promise<void> {
+  async setServerFeatures(): Promise<void> {
     const services = this.getServices(this.props.http);
     const serverFeatures = await services.notificationService.getServerFeatures();
     const defaultConfigTypes = [
@@ -146,7 +147,7 @@ export default class Main extends Component<MainProps, MainState> {
 
   onSelectedDataSources = (dataSources: DataSourceOption[]) => {
     const { id = "", label = "" } = dataSources[0] || {};
-    if (this.state.dataSourceId !== id || this.state.dataSourceLabel !==label) {
+    if (this.state.dataSourceId !== id || this.state.dataSourceLabel !== label) {
       this.setState({
         dataSourceId: id,
         dataSourceLabel: label,
@@ -239,76 +240,48 @@ export default class Main extends Component<MainProps, MainState> {
                 {(services: BrowserServices | null) =>
                   services && (
                     <MainContext.Provider value={this.state}>
-                    <ModalProvider>
-                      <DataSourceMenuContext.Provider
-                        value={{
-                          dataSourceId: this.state.dataSourceId,
-                          dataSourceLabel: this.state.dataSourceLabel,
-                          multiDataSourceEnabled: this.props.multiDataSourceEnabled,
-                        }}
-                      >
-                        {this.props.multiDataSourceEnabled && DataSourceMenuView && DataSourceMenuSelectable && (
-                          <Switch>
-                            <Route
-                              path={[
-                                `${ROUTES.EDIT_CHANNEL}/:id`,
-                                `${ROUTES.CHANNEL_DETAILS}/:id`,
-                                `${ROUTES.EDIT_SENDER}/:id`,
-                                `${ROUTES.EDIT_RECIPIENT_GROUP}/:id`,
-                                `${ROUTES.EDIT_SES_SENDER}/:id`
-                              ]}
-                              render={() => (
-                                <DataSourceMenuView
-                                  setMenuMountPoint={this.props.setActionMenu}
-                                  componentType={"DataSourceView"}
-                                  componentConfig={{
-                                    activeOption: [{ label: this.state.dataSourceLabel, id: this.state.dataSourceId }],
-                                    dataSourceFilter: this.dataSourceFilterFn,
-                                  }}
-                                />
-                              )}
-                            />
-                            <Route
-                              path={[
-                                "/",
-                                ROUTES.CHANNELS,
-                                ROUTES.CREATE_CHANNEL,
-                                ROUTES.CREATE_SENDER,
-                                ROUTES.CREATE_SES_SENDER,
-                                ROUTES.CREATE_RECIPIENT_GROUP,
-                                ROUTES.EMAIL_GROUPS,
-                                ROUTES.EMAIL_SENDERS,
-                                ROUTES.NOTIFICATIONS,
-                              ]}
-                              render={() => (
-                                <DataSourceMenuSelectable
-                                  setMenuMountPoint={this.props.setActionMenu}
-                                  componentType={"DataSourceSelectable"}
-                                  componentConfig={{
-                                    savedObjects: core?.savedObjects.client,
-                                    notifications: core?.notifications,
-                                    fullWidth: false,
-                                    activeOption,
-                                    onSelectedDataSources: this.onSelectedDataSources,
-                                    dataSourceFilter: this.dataSourceFilterFn,
-                                  }}
-                                />
-                              )}
-                            />
-                            <Route
-                              path={[ROUTES.CREATE_SES_SENDER, ROUTES.CREATE_CHANNEL, ROUTES.CREATE_RECIPIENT_GROUP, ROUTES.CREATE_SENDER]}
-                              render={() =>
-                                this.state.dataSourceReadOnly ? (
+                      <ModalProvider>
+                        <DataSourceMenuContext.Provider
+                          value={{
+                            dataSourceId: this.state.dataSourceId,
+                            dataSourceLabel: this.state.dataSourceLabel,
+                            multiDataSourceEnabled: this.props.multiDataSourceEnabled,
+                          }}
+                        >
+                          {this.props.multiDataSourceEnabled && DataSourceMenuView && DataSourceMenuSelectable && (
+                            <Switch>
+                              <Route
+                                path={[
+                                  `${ROUTES.EDIT_CHANNEL}/:id`,
+                                  `${ROUTES.CHANNEL_DETAILS}/:id`,
+                                  `${ROUTES.EDIT_SENDER}/:id`,
+                                  `${ROUTES.EDIT_RECIPIENT_GROUP}/:id`,
+                                  `${ROUTES.EDIT_SES_SENDER}/:id`
+                                ]}
+                                render={() => (
                                   <DataSourceMenuView
                                     setMenuMountPoint={this.props.setActionMenu}
                                     componentType={"DataSourceView"}
                                     componentConfig={{
                                       activeOption: [{ label: this.state.dataSourceLabel, id: this.state.dataSourceId }],
-                                      fullWidth: false,
                                       dataSourceFilter: this.dataSourceFilterFn,
                                     }}
                                   />
-                                ) : (
+                                )}
+                              />
+                              <Route
+                                path={[
+                                  "/",
+                                  ROUTES.CHANNELS,
+                                  ROUTES.CREATE_CHANNEL,
+                                  ROUTES.CREATE_SENDER,
+                                  ROUTES.CREATE_SES_SENDER,
+                                  ROUTES.CREATE_RECIPIENT_GROUP,
+                                  ROUTES.EMAIL_GROUPS,
+                                  ROUTES.EMAIL_SENDERS,
+                                  ROUTES.NOTIFICATIONS,
+                                ]}
+                                render={() => (
                                   <DataSourceMenuSelectable
                                     setMenuMountPoint={this.props.setActionMenu}
                                     componentType={"DataSourceSelectable"}
@@ -321,133 +294,163 @@ export default class Main extends Component<MainProps, MainState> {
                                       dataSourceFilter: this.dataSourceFilterFn,
                                     }}
                                   />
-                                )
-                              }
-                            />
-                          </Switch>
-                        )}
-                      <EuiPage>
-                        {!this.state.dataSourceLoading && (
-                          <>
-                        <ModalRoot services={services} />
-                        {pathname !== ROUTES.CREATE_CHANNEL &&
-                          !pathname.startsWith(ROUTES.EDIT_CHANNEL) &&
-                          !pathname.startsWith(ROUTES.CHANNEL_DETAILS) &&
-                          pathname !== ROUTES.CREATE_SENDER &&
-                          !pathname.startsWith(ROUTES.EDIT_SENDER) &&
-                          pathname !== ROUTES.CREATE_SES_SENDER &&
-                          !pathname.startsWith(ROUTES.EDIT_SES_SENDER) &&
-                          pathname !== ROUTES.CREATE_RECIPIENT_GROUP &&
-                          !pathname.startsWith(ROUTES.EDIT_RECIPIENT_GROUP) && (
-                            <EuiPageSideBar style={{ minWidth: 155 }}>
-                              <EuiSideNav
-                                style={{ width: 155 }}
-                                items={sideNav}
+                                )}
                               />
-                            </EuiPageSideBar>
+                              <Route
+                                path={[ROUTES.CREATE_SES_SENDER, ROUTES.CREATE_CHANNEL, ROUTES.CREATE_RECIPIENT_GROUP, ROUTES.CREATE_SENDER]}
+                                render={() =>
+                                  this.state.dataSourceReadOnly ? (
+                                    <DataSourceMenuView
+                                      setMenuMountPoint={this.props.setActionMenu}
+                                      componentType={"DataSourceView"}
+                                      componentConfig={{
+                                        activeOption: [{ label: this.state.dataSourceLabel, id: this.state.dataSourceId }],
+                                        fullWidth: false,
+                                        dataSourceFilter: this.dataSourceFilterFn,
+                                      }}
+                                    />
+                                  ) : (
+                                    <DataSourceMenuSelectable
+                                      setMenuMountPoint={this.props.setActionMenu}
+                                      componentType={"DataSourceSelectable"}
+                                      componentConfig={{
+                                        savedObjects: core?.savedObjects.client,
+                                        notifications: core?.notifications,
+                                        fullWidth: false,
+                                        activeOption,
+                                        onSelectedDataSources: this.onSelectedDataSources,
+                                        dataSourceFilter: this.dataSourceFilterFn,
+                                      }}
+                                    />
+                                  )
+                                }
+                              />
+                            </Switch>
                           )}
-                        <EuiPageBody>
-                          <Switch>
-                            <Route
-                              path={ROUTES.CREATE_CHANNEL}
-                              render={(props: RouteComponentProps) => (
-                                <CreateChannel {...props} />
-                              )}
-                            />
-                            <Route
-                              path={`${ROUTES.EDIT_CHANNEL}/:id`}
-                              render={(
-                                props: RouteComponentProps<{ id: string }>
-                              ) => <CreateChannel {...props} edit={true} />}
-                            />
-                            <Route
-                              path={`${ROUTES.CHANNEL_DETAILS}/:id`}
-                              render={(
-                                props: RouteComponentProps<{ id: string }>
-                              ) => <ChannelDetails {...props} />}
-                            />
-                            <Route
-                              path={ROUTES.CHANNELS}
-                              render={(props: RouteComponentProps) => (
-                                <Channels
-                                  {...props}
-                                  notificationService={
-                                    services?.notificationService as NotificationService
-                                  }
-                                />
-                              )}
-                            />
-                            <Route
-                              path={ROUTES.EMAIL_SENDERS}
-                              render={(props: RouteComponentProps) => (
-                                <EmailSenders
-                                  {...props}
-                                  notificationService={
-                                    services?.notificationService as NotificationService
-                                  }
-                                /> // send dataSourceId as props or externally
-                              )}
-                            />
-                            <Route
-                              path={ROUTES.EMAIL_GROUPS}
-                              render={(props: RouteComponentProps) => (
-                                <EmailGroups
-                                  {...props}
-                                  notificationService={
-                                    services?.notificationService as NotificationService
-                                  }
-                                />
-                              )}
-                            />
-                            <Route
-                              path={ROUTES.CREATE_SENDER}
-                              render={(props: RouteComponentProps) => (
-                                <CreateSender
-                                  {...props}
-                                />
-                              )}
-                            />
-                            <Route
-                              path={`${ROUTES.EDIT_SENDER}/:id`}
-                              render={(props: RouteComponentProps) => (
-                                <CreateSender {...props} edit={true} />
-                              )}
-                            />
-                            <Route
-                              path={ROUTES.CREATE_SES_SENDER}
-                              render={(props: RouteComponentProps) => (
-                                <CreateSESSender
-                                  {...props}
-                                />
-                              )}
-                            />
-                            <Route
-                              path={`${ROUTES.EDIT_SES_SENDER}/:id`}
-                              render={(props: RouteComponentProps) => (
-                                <CreateSESSender {...props} edit={true} />
-                              )}
-                            />
-                            <Route
-                              path={ROUTES.CREATE_RECIPIENT_GROUP}
-                              render={(props: RouteComponentProps) => (
-                                <CreateRecipientGroup
-                                  {...props}
-                                />
-                              )}
-                            />
-                            <Route
-                              path={`${ROUTES.EDIT_RECIPIENT_GROUP}/:id`}
-                              render={(props: RouteComponentProps) => (
-                                <CreateRecipientGroup {...props} edit={true} />
-                              )}
-                            />
-                            <Redirect from="/" to={ROUTES.CHANNELS} />
-                          </Switch>
-                        </EuiPageBody></>
-                        )}
-                      </EuiPage>
-                      </DataSourceMenuContext.Provider>
-                    </ModalProvider>
+                          <EuiPage>
+                            {!this.state.dataSourceLoading && (
+                              <>
+                                <ModalRoot services={services} />
+                                {pathname !== ROUTES.CREATE_CHANNEL &&
+                                  !pathname.startsWith(ROUTES.EDIT_CHANNEL) &&
+                                  !pathname.startsWith(ROUTES.CHANNEL_DETAILS) &&
+                                  pathname !== ROUTES.CREATE_SENDER &&
+                                  !pathname.startsWith(ROUTES.EDIT_SENDER) &&
+                                  pathname !== ROUTES.CREATE_SES_SENDER &&
+                                  !pathname.startsWith(ROUTES.EDIT_SES_SENDER) &&
+                                  pathname !== ROUTES.CREATE_RECIPIENT_GROUP &&
+                                  !pathname.startsWith(ROUTES.EDIT_RECIPIENT_GROUP) &&
+                                  // Conditionally render sidebar based on the feature flag
+                                  !core.chrome.navGroup.getNavGroupEnabled() && (
+                                    <EuiPageSideBar style={{ minWidth: 155 }}>
+                                      <EuiSideNav
+                                        style={{ width: 155 }}
+                                        items={sideNav}
+                                      />
+                                    </EuiPageSideBar>
+                                  )}
+                                <EuiPageBody>
+                                  <Switch>
+                                    <Route
+                                      path={ROUTES.CREATE_CHANNEL}
+                                      render={(props: RouteComponentProps) => (
+                                        <CreateChannel {...props} />
+                                      )}
+                                    />
+                                    <Route
+                                      path={`${ROUTES.EDIT_CHANNEL}/:id`}
+                                      render={(
+                                        props: RouteComponentProps<{ id: string }>
+                                      ) => <CreateChannel {...props} edit={true} />}
+                                    />
+                                    <Route
+                                      path={`${ROUTES.CHANNEL_DETAILS}/:id`}
+                                      render={(
+                                        props: RouteComponentProps<{ id: string }>
+                                      ) => <ChannelDetails {...props} />}
+                                    />
+                                    <Route
+                                      path={ROUTES.CHANNELS}
+                                      render={(props: RouteComponentProps) => (
+                                        <Channels
+                                          {...props}
+                                          notificationService={
+                                            services?.notificationService as NotificationService
+                                          }
+                                        />
+                                      )}
+                                    />
+                                    <Route
+                                      path={ROUTES.EMAIL_SENDERS}
+                                      render={(props: RouteComponentProps) => (
+                                        <EmailSenders
+                                          {...props}
+                                          notificationService={
+                                            services?.notificationService as NotificationService
+                                          }
+                                        /> // send dataSourceId as props or externally
+                                      )}
+                                    />
+                                    <Route
+                                      path={ROUTES.EMAIL_GROUPS}
+                                      render={(props: RouteComponentProps) => (
+                                        <EmailGroups
+                                          {...props}
+                                          notificationService={
+                                            services?.notificationService as NotificationService
+                                          }
+                                        />
+                                      )}
+                                    />
+                                    <Route
+                                      path={ROUTES.CREATE_SENDER}
+                                      render={(props: RouteComponentProps) => (
+                                        <CreateSender
+                                          {...props}
+                                        />
+                                      )}
+                                    />
+                                    <Route
+                                      path={`${ROUTES.EDIT_SENDER}/:id`}
+                                      render={(props: RouteComponentProps) => (
+                                        <CreateSender {...props} edit={true} />
+                                      )}
+                                    />
+                                    <Route
+                                      path={ROUTES.CREATE_SES_SENDER}
+                                      render={(props: RouteComponentProps) => (
+                                        <CreateSESSender
+                                          {...props}
+                                        />
+                                      )}
+                                    />
+                                    <Route
+                                      path={`${ROUTES.EDIT_SES_SENDER}/:id`}
+                                      render={(props: RouteComponentProps) => (
+                                        <CreateSESSender {...props} edit={true} />
+                                      )}
+                                    />
+                                    <Route
+                                      path={ROUTES.CREATE_RECIPIENT_GROUP}
+                                      render={(props: RouteComponentProps) => (
+                                        <CreateRecipientGroup
+                                          {...props}
+                                        />
+                                      )}
+                                    />
+                                    <Route
+                                      path={`${ROUTES.EDIT_RECIPIENT_GROUP}/:id`}
+                                      render={(props: RouteComponentProps) => (
+                                        <CreateRecipientGroup {...props} edit={true} />
+                                      )}
+                                    />
+                                    <Redirect from="/" to={core.chrome.navGroup.getNavGroupEnabled() ? this.props.defaultRoute : ROUTES.CHANNELS} />
+                                  </Switch>
+                                </EuiPageBody></>
+                            )}
+                          </EuiPage>
+                        </DataSourceMenuContext.Provider>
+                      </ModalProvider>
                     </MainContext.Provider>
                   )
                 }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -111,20 +111,17 @@ export class notificationsDashboardsPlugin
         },
       });
 
-      const navLinks = [
-        {
-          id: `channels`,
-          parentNavLinkId: PLUGIN_NAME
-        },
-        {
-          id: `email_senders`,
-          parentNavLinkId: PLUGIN_NAME
-        },
-        {
-          id: `email_groups`,
-          parentNavLinkId: PLUGIN_NAME
-        },
-      ];
+      const navlinks = [
+        { id: 'channels', parent: PLUGIN_NAME },
+        { id: 'email_senders', parent: PLUGIN_NAME },
+        { id: 'email_groups', parent: PLUGIN_NAME }
+      ]
+
+      const navLinks = navlinks.map(item => ({
+        id: item.id,
+        parentNavLinkId: item.parent
+      }));
+
       core.chrome.navGroup.addNavLinksToGroup(
         DEFAULT_NAV_GROUPS.settingsAndSetup,
         navLinks

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -76,7 +76,6 @@ export class notificationsDashboardsPlugin
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
         {
           id: PLUGIN_NAME,
-          showInAllNavGroup: true
         }
       ])
 

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -5,6 +5,7 @@
 
 import { i18n } from '@osd/i18n';
 import {
+  AppCategory,
   AppMountParameters,
   CoreSetup,
   CoreStart,
@@ -46,7 +47,7 @@ export class notificationsDashboardsPlugin
     core.application.register({
       id: PLUGIN_NAME,
       title: this.title,
-      category: DEFAULT_APP_CATEGORIES.management,
+      category: core.chrome?.navGroup?.getNavGroupEnabled() ? undefined : DEFAULT_APP_CATEGORIES.management,
       order: 9060,
       workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
       async mount(params: AppMountParameters) {
@@ -71,45 +72,46 @@ export class notificationsDashboardsPlugin
       });
     }
 
-    // register applications with category and use case information
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
-      {
-        id: PLUGIN_NAME,
-        showInAllNavGroup: false
-      }
-    ])
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], [
-      {
-        id: PLUGIN_NAME,
-        showInAllNavGroup: false
-      }
-    ])
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.analytics, [
-      {
-        id: PLUGIN_NAME,
-        showInAllNavGroup: false
-      }
-    ])
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
-      {
-        id: PLUGIN_NAME,
-        showInAllNavGroup: true
-      }
-    ])
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [
-      {
-        id: PLUGIN_NAME,
-        showInAllNavGroup: false
-      }
-    ])
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.dataAdministration, [
-      {
-        id: PLUGIN_NAME,
-        showInAllNavGroup: false
-      }
-    ])
-
     if (core.chrome.navGroup.getNavGroupEnabled()) {
+
+      // register applications with category and use case information
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+        {
+          id: PLUGIN_NAME,
+          showInAllNavGroup: false
+        }
+      ])
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], [
+        {
+          id: PLUGIN_NAME,
+          showInAllNavGroup: false
+        }
+      ])
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.analytics, [
+        {
+          id: PLUGIN_NAME,
+          showInAllNavGroup: false
+        }
+      ])
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
+        {
+          id: PLUGIN_NAME,
+          showInAllNavGroup: true
+        }
+      ])
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [
+        {
+          id: PLUGIN_NAME,
+          showInAllNavGroup: false
+        }
+      ])
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.dataAdministration, [
+        {
+          id: PLUGIN_NAME,
+          showInAllNavGroup: false
+        }
+      ])
+
       // channels route
       core.application.register({
         id: `channels`,

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -6,7 +6,6 @@
 import { i18n } from '@osd/i18n';
 import {
   AppMountParameters,
-  AppCategory,
   CoreSetup,
   CoreStart,
   DEFAULT_APP_CATEGORIES,
@@ -20,15 +19,14 @@ import {
   NotificationsDashboardsSetupDeps,
 } from './types';
 import { PLUGIN_NAME } from '../common';
-import { AppPluginStartDependencies } from './types';
 import { ROUTES } from './utils/constants';
 
 export class notificationsDashboardsPlugin
   implements
-    Plugin<
-      notificationsDashboardsPluginSetup,
-      notificationsDashboardsPluginStart
-    > {
+  Plugin<
+    notificationsDashboardsPluginSetup,
+    notificationsDashboardsPluginStart
+  > {
   private title = i18n.translate('notification.notificationTitle', {
     defaultMessage: 'Notifications',
   });
@@ -41,7 +39,7 @@ export class notificationsDashboardsPlugin
     const mountWrapper = async (params: AppMountParameters, redirect: string) => {
       const { renderApp } = await import("./application");
       const [coreStart, depsStart] = await core.getStartServices();
-      return renderApp(coreStart, params, dataSourceManagement, depsStart, redirect);
+      return renderApp(coreStart, params, dataSourceManagement!, depsStart, redirect);
     };
 
     // Register an application into the side navigation menu
@@ -57,7 +55,7 @@ export class notificationsDashboardsPlugin
         // Get start services as specified in opensearch_dashboards.json
         const [coreStart, depsStart] = await core.getStartServices();
         // Render the application
-        return renderApp(coreStart, params, dataSourceManagement, depsStart, ROUTES.CHANNELS);
+        return renderApp(coreStart, params, dataSourceManagement!, depsStart, ROUTES.CHANNELS);
       },
     });
 
@@ -73,13 +71,51 @@ export class notificationsDashboardsPlugin
       });
     }
 
-    if (core.chrome.navGroup.getNavGroupEnabled()) {
+    // register applications with category and use case information
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+      {
+        id: PLUGIN_NAME,
+        showInAllNavGroup: false
+      }
+    ])
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], [
+      {
+        id: PLUGIN_NAME,
+        showInAllNavGroup: false
+      }
+    ])
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.analytics, [
+      {
+        id: PLUGIN_NAME,
+        showInAllNavGroup: false
+      }
+    ])
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
+      {
+        id: PLUGIN_NAME,
+        showInAllNavGroup: true
+      }
+    ])
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [
+      {
+        id: PLUGIN_NAME,
+        showInAllNavGroup: false
+      }
+    ])
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.dataAdministration, [
+      {
+        id: PLUGIN_NAME,
+        showInAllNavGroup: false
+      }
+    ])
 
+    if (core.chrome.navGroup.getNavGroupEnabled()) {
       // channels route
       core.application.register({
         id: `channels`,
         title: 'Channels',
         order: 9070,
+        workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.CHANNELS);
         },
@@ -88,7 +124,8 @@ export class notificationsDashboardsPlugin
       core.application.register({
         id: `email_senders`,
         title: 'Email senders',
-        order: 9070,
+        order: 9080,
+        workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.EMAIL_SENDERS);
         },
@@ -97,32 +134,50 @@ export class notificationsDashboardsPlugin
       core.application.register({
         id: `email_groups`,
         title: 'Email recepient groups',
-        order: 9070,
+        order: 9090,
+        workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         mount: async (params: AppMountParameters) => {
           return mountWrapper(params, ROUTES.EMAIL_GROUPS);
         },
       });
 
+      const navLinks = [
+        {
+          id: `channels`,
+          parentNavLinkId: PLUGIN_NAME
+        },
+        {
+          id: `email_senders`,
+          parentNavLinkId: PLUGIN_NAME
+        },
+        {
+          id: `email_groups`,
+          parentNavLinkId: PLUGIN_NAME
+        },
+      ];
       core.chrome.navGroup.addNavLinksToGroup(
         DEFAULT_NAV_GROUPS.settingsAndSetup,
-        [
-          {
-            id: PLUGIN_NAME,
-          },
-          {
-            id: `channels`,
-            parentNavLinkId: PLUGIN_NAME
-          },
-          {
-            id: `email_senders`,
-            parentNavLinkId: PLUGIN_NAME
-          },
-          {
-            id: `email_groups`,
-            parentNavLinkId: PLUGIN_NAME
-          },
-      
-        ]
+        navLinks
+      );
+      core.chrome.navGroup.addNavLinksToGroup(
+        DEFAULT_NAV_GROUPS.search,
+        navLinks
+      );
+      core.chrome.navGroup.addNavLinksToGroup(
+        DEFAULT_NAV_GROUPS['security-analytics'],
+        navLinks
+      );
+      core.chrome.navGroup.addNavLinksToGroup(
+        DEFAULT_NAV_GROUPS.analytics,
+        navLinks
+      );
+      core.chrome.navGroup.addNavLinksToGroup(
+        DEFAULT_NAV_GROUPS.dataAdministration,
+        navLinks
+      );
+      core.chrome.navGroup.addNavLinksToGroup(
+        DEFAULT_NAV_GROUPS.observability,
+        navLinks
       );
     }
 
@@ -134,5 +189,5 @@ export class notificationsDashboardsPlugin
     return {};
   }
 
-  public stop() {}
+  public stop() { }
 }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -6,10 +6,13 @@
 import { i18n } from '@osd/i18n';
 import {
   AppMountParameters,
+  AppCategory,
   CoreSetup,
   CoreStart,
   DEFAULT_APP_CATEGORIES,
+  DEFAULT_NAV_GROUPS,
   Plugin,
+  WorkspaceAvailability
 } from '../../../src/core/public';
 import {
   notificationsDashboardsPluginSetup,
@@ -18,6 +21,7 @@ import {
 } from './types';
 import { PLUGIN_NAME } from '../common';
 import { AppPluginStartDependencies } from './types';
+import { ROUTES } from './utils/constants';
 
 export class notificationsDashboardsPlugin
   implements
@@ -33,19 +37,27 @@ export class notificationsDashboardsPlugin
     core: CoreSetup,
     { managementOverview, dataSourceManagement }: NotificationsDashboardsSetupDeps,
   ): notificationsDashboardsPluginSetup {
+
+    const mountWrapper = async (params: AppMountParameters, redirect: string) => {
+      const { renderApp } = await import("./application");
+      const [coreStart, depsStart] = await core.getStartServices();
+      return renderApp(coreStart, params, dataSourceManagement, depsStart, redirect);
+    };
+
     // Register an application into the side navigation menu
     core.application.register({
       id: PLUGIN_NAME,
       title: this.title,
       category: DEFAULT_APP_CATEGORIES.management,
       order: 9060,
+      workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application');
         // Get start services as specified in opensearch_dashboards.json
         const [coreStart, depsStart] = await core.getStartServices();
         // Render the application
-        return renderApp(coreStart, params, dataSourceManagement, depsStart);
+        return renderApp(coreStart, params, dataSourceManagement, depsStart, ROUTES.CHANNELS);
       },
     });
 
@@ -59,6 +71,59 @@ export class notificationsDashboardsPlugin
             'Connect with your communication services to receive notifications from supported OpenSearch plugins.',
         }),
       });
+    }
+
+    if (core.chrome.navGroup.getNavGroupEnabled()) {
+
+      // channels route
+      core.application.register({
+        id: `channels`,
+        title: 'Channels',
+        order: 9070,
+        mount: async (params: AppMountParameters) => {
+          return mountWrapper(params, ROUTES.CHANNELS);
+        },
+      });
+
+      core.application.register({
+        id: `email_senders`,
+        title: 'Email senders',
+        order: 9070,
+        mount: async (params: AppMountParameters) => {
+          return mountWrapper(params, ROUTES.EMAIL_SENDERS);
+        },
+      });
+
+      core.application.register({
+        id: `email_groups`,
+        title: 'Email recepient groups',
+        order: 9070,
+        mount: async (params: AppMountParameters) => {
+          return mountWrapper(params, ROUTES.EMAIL_GROUPS);
+        },
+      });
+
+      core.chrome.navGroup.addNavLinksToGroup(
+        DEFAULT_NAV_GROUPS.settingsAndSetup,
+        [
+          {
+            id: PLUGIN_NAME,
+          },
+          {
+            id: `channels`,
+            parentNavLinkId: PLUGIN_NAME
+          },
+          {
+            id: `email_senders`,
+            parentNavLinkId: PLUGIN_NAME
+          },
+          {
+            id: `email_groups`,
+            parentNavLinkId: PLUGIN_NAME
+          },
+      
+        ]
+      );
     }
 
     // Return methods that should be available to other plugins

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -5,7 +5,6 @@
 
 import { i18n } from '@osd/i18n';
 import {
-  AppCategory,
   AppMountParameters,
   CoreSetup,
   CoreStart,

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -72,42 +72,11 @@ export class notificationsDashboardsPlugin
     }
 
     if (core.chrome.navGroup.getNavGroupEnabled()) {
-
       // register applications with category and use case information
-      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
-        {
-          id: PLUGIN_NAME,
-          showInAllNavGroup: false
-        }
-      ])
-      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], [
-        {
-          id: PLUGIN_NAME,
-          showInAllNavGroup: false
-        }
-      ])
-      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.analytics, [
-        {
-          id: PLUGIN_NAME,
-          showInAllNavGroup: false
-        }
-      ])
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
         {
           id: PLUGIN_NAME,
           showInAllNavGroup: true
-        }
-      ])
-      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [
-        {
-          id: PLUGIN_NAME,
-          showInAllNavGroup: false
-        }
-      ])
-      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.dataAdministration, [
-        {
-          id: PLUGIN_NAME,
-          showInAllNavGroup: false
         }
       ])
 
@@ -158,26 +127,6 @@ export class notificationsDashboardsPlugin
       ];
       core.chrome.navGroup.addNavLinksToGroup(
         DEFAULT_NAV_GROUPS.settingsAndSetup,
-        navLinks
-      );
-      core.chrome.navGroup.addNavLinksToGroup(
-        DEFAULT_NAV_GROUPS.search,
-        navLinks
-      );
-      core.chrome.navGroup.addNavLinksToGroup(
-        DEFAULT_NAV_GROUPS['security-analytics'],
-        navLinks
-      );
-      core.chrome.navGroup.addNavLinksToGroup(
-        DEFAULT_NAV_GROUPS.analytics,
-        navLinks
-      );
-      core.chrome.navGroup.addNavLinksToGroup(
-        DEFAULT_NAV_GROUPS.dataAdministration,
-        navLinks
-      );
-      core.chrome.navGroup.addNavLinksToGroup(
-        DEFAULT_NAV_GROUPS.observability,
         navLinks
       );
     }


### PR DESCRIPTION
### Description
* This PR adds side navigation changes to notification plugin when feature is enabled

### Issues Resolved

After side nav changes, when feature is enabled

![Image 7-18-24 at 5 39 PM (1)](https://github.com/user-attachments/assets/7b6782fe-60d9-4194-9ecd-091f5352e4d7)
![Image 7-18-24 at 5 39 PM](https://github.com/user-attachments/assets/fdd942f6-3407-4dd9-b668-4f2d7c5520dd)



When feature is disabled:

![Image 7-18-24 at 7 22 AM](https://github.com/user-attachments/assets/41aa2bb4-1a6c-4b02-9c4b-0789e2f0afb3)



### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
