### PR TITLE
Use smaller and compressed varients of buttons and form components

### DIFF
--- a/public/pages/Channels/Channels.tsx
+++ b/public/pages/Channels/Channels.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiEmptyPrompt,
   EuiHealth,
   EuiHorizontalRule,
@@ -238,9 +238,9 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
                 },
                 {
                   component: (
-                    <EuiButton fill href={`#${ROUTES.CREATE_CHANNEL}`}>
+                    <EuiSmallButton fill href={`#${ROUTES.CREATE_CHANNEL}`}>
                       Create channel
-                    </EuiButton>
+                    </EuiSmallButton>
                   ),
                 },
               ]}
@@ -269,9 +269,9 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
                 title={<h2>No channels to display</h2>}
                 body="To send or receive notifications, you will need to create a notification channel."
                 actions={
-                  <EuiButton href={`#${ROUTES.CREATE_CHANNEL}`}>
+                  <EuiSmallButton href={`#${ROUTES.CREATE_CHANNEL}`}>
                     Create channel
-                  </EuiButton>
+                  </EuiSmallButton>
                 }
               />
             }

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelActions.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelActions.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<ChannelActions/> spec clicks in the popover 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -48,7 +48,7 @@ exports[`<ChannelActions/> spec renders the action button disabled by default 1`
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -87,7 +87,7 @@ exports[`<ChannelActions/> spec renders the popover 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -127,7 +127,7 @@ exports[`<ChannelActions/> spec renders the popover with multiple selected chann
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`<ChannelControls /> spec renders the component 1`] = `
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
           placeholder="Search"
           type="search"
         />
@@ -26,7 +26,7 @@ exports[`<ChannelControls /> spec renders the component 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
               focusable="false"
               height="16"
               role="img"
@@ -56,7 +56,7 @@ exports[`<ChannelControls /> spec renders the component 1`] = `
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
             type="button"
           >
             <span
@@ -98,7 +98,7 @@ exports[`<ChannelControls /> spec renders the component 1`] = `
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
             type="button"
           >
             <span

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelDetailsActions.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelDetailsActions.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<ChannelDetailsActions /> spec clicks buttons in popover 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -48,7 +48,7 @@ exports[`<ChannelDetailsActions /> spec opens popover 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span
@@ -88,7 +88,7 @@ exports[`<ChannelDetailsActions /> spec renders the component 1`] = `
     class="euiPopover__anchor"
   >
     <button
-      class="euiButton euiButton--primary"
+      class="euiButton euiButton--primary euiButton--small"
       type="button"
     >
       <span

--- a/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButton euiButton--primary euiButton-isDisabled"
+                    class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                     disabled=""
                     type="button"
                   >
@@ -79,7 +79,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <a
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 href="#/create-channel"
                 rel="noreferrer"
               >
@@ -112,13 +112,13 @@ exports[`<Channels/> spec renders the empty component 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
-              class="euiFieldSearch euiFieldSearch--fullWidth"
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
               placeholder="Search"
               type="search"
             />
@@ -130,7 +130,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                   focusable="false"
                   height="16"
                   role="img"
@@ -160,7 +160,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
               class="euiPopover__anchor"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
                 type="button"
               >
                 <span
@@ -202,7 +202,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
               class="euiPopover__anchor"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
                 type="button"
               >
                 <span
@@ -511,7 +511,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
                         class="euiSpacer euiSpacer--l"
                       />
                       <a
-                        class="euiButton euiButton--primary"
+                        class="euiButton euiButton--primary euiButton--small"
                         href="#/create-channel"
                         rel="noreferrer"
                       >

--- a/public/pages/Channels/__tests__/__snapshots__/DetailsListModal.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/DetailsListModal.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                         class="euiModalFooter"
                       >
                         <button
-                          class="euiButton euiButton--primary euiButton--fill"
+                          class="euiButton euiButton--primary euiButton--small euiButton--fill"
                           type="button"
                         >
                           <span
@@ -397,7 +397,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                 class="euiModalFooter"
                               >
                                 <button
-                                  class="euiButton euiButton--primary euiButton--fill"
+                                  class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                   type="button"
                                 >
                                   <span
@@ -560,7 +560,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                   class="euiModalFooter"
                                 >
                                   <button
-                                    class="euiButton euiButton--primary euiButton--fill"
+                                    class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                     type="button"
                                   >
                                     <span
@@ -723,7 +723,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                     class="euiModalFooter"
                                   >
                                     <button
-                                      class="euiButton euiButton--primary euiButton--fill"
+                                      class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                       type="button"
                                     >
                                       <span
@@ -874,7 +874,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                       class="euiModalFooter"
                                     >
                                       <button
-                                        class="euiButton euiButton--primary euiButton--fill"
+                                        class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                         type="button"
                                       >
                                         <span
@@ -1135,52 +1135,59 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                               <div
                                 className="euiModalFooter"
                               >
-                                <EuiButton
+                                <EuiSmallButton
                                   fill={true}
                                   onClick={[MockFunction]}
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButton"
-                                    disabled={false}
-                                    element="button"
+                                  <EuiButton
                                     fill={true}
-                                    isDisabled={false}
                                     onClick={[MockFunction]}
-                                    type="button"
+                                    size="s"
                                   >
-                                    <button
-                                      className="euiButton euiButton--primary euiButton--fill"
+                                    <EuiButtonDisplay
+                                      baseClassName="euiButton"
                                       disabled={false}
+                                      element="button"
+                                      fill={true}
+                                      isDisabled={false}
                                       onClick={[MockFunction]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                      size="s"
                                       type="button"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
+                                      <button
+                                        className="euiButton euiButton--primary euiButton--small euiButton--fill"
+                                        disabled={false}
+                                        onClick={[MockFunction]}
+                                        style={
                                           Object {
-                                            "className": "euiButton__text",
+                                            "minWidth": undefined,
                                           }
                                         }
+                                        type="button"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
+                                        <EuiButtonContent
+                                          className="euiButton__content"
+                                          iconSide="left"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButton__text",
+                                            }
+                                          }
                                         >
                                           <span
-                                            className="euiButton__text"
+                                            className="euiButtonContent euiButton__content"
                                           >
-                                            Close
+                                            <span
+                                              className="euiButton__text"
+                                            >
+                                              Close
+                                            </span>
                                           </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonDisplay>
-                                </EuiButton>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonDisplay>
+                                  </EuiButton>
+                                </EuiSmallButton>
                               </div>
                             </EuiModalFooter>
                           </div>

--- a/public/pages/Channels/__tests__/__snapshots__/DetailsTableModal.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/DetailsTableModal.test.tsx.snap
@@ -230,7 +230,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                         class="euiModalFooter"
                       >
                         <button
-                          class="euiButton euiButton--primary euiButton--fill"
+                          class="euiButton euiButton--primary euiButton--small euiButton--fill"
                           type="button"
                         >
                           <span
@@ -525,7 +525,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                 class="euiModalFooter"
                               >
                                 <button
-                                  class="euiButton euiButton--primary euiButton--fill"
+                                  class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                   type="button"
                                 >
                                   <span
@@ -752,7 +752,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                   class="euiModalFooter"
                                 >
                                   <button
-                                    class="euiButton euiButton--primary euiButton--fill"
+                                    class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                     type="button"
                                   >
                                     <span
@@ -979,7 +979,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                     class="euiModalFooter"
                                   >
                                     <button
-                                      class="euiButton euiButton--primary euiButton--fill"
+                                      class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                       type="button"
                                     >
                                       <span
@@ -1194,7 +1194,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                       class="euiModalFooter"
                                     >
                                       <button
-                                        class="euiButton euiButton--primary euiButton--fill"
+                                        class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                         type="button"
                                       >
                                         <span
@@ -1715,52 +1715,59 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                               <div
                                 className="euiModalFooter"
                               >
-                                <EuiButton
+                                <EuiSmallButton
                                   fill={true}
                                   onClick={[MockFunction]}
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButton"
-                                    disabled={false}
-                                    element="button"
+                                  <EuiButton
                                     fill={true}
-                                    isDisabled={false}
                                     onClick={[MockFunction]}
-                                    type="button"
+                                    size="s"
                                   >
-                                    <button
-                                      className="euiButton euiButton--primary euiButton--fill"
+                                    <EuiButtonDisplay
+                                      baseClassName="euiButton"
                                       disabled={false}
+                                      element="button"
+                                      fill={true}
+                                      isDisabled={false}
                                       onClick={[MockFunction]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                      size="s"
                                       type="button"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
+                                      <button
+                                        className="euiButton euiButton--primary euiButton--small euiButton--fill"
+                                        disabled={false}
+                                        onClick={[MockFunction]}
+                                        style={
                                           Object {
-                                            "className": "euiButton__text",
+                                            "minWidth": undefined,
                                           }
                                         }
+                                        type="button"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
+                                        <EuiButtonContent
+                                          className="euiButton__content"
+                                          iconSide="left"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButton__text",
+                                            }
+                                          }
                                         >
                                           <span
-                                            className="euiButton__text"
+                                            className="euiButtonContent euiButton__content"
                                           >
-                                            Close
+                                            <span
+                                              className="euiButton__text"
+                                            >
+                                              Close
+                                            </span>
                                           </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonDisplay>
-                                </EuiButton>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonDisplay>
+                                  </EuiButton>
+                                </EuiSmallButton>
                               </div>
                             </EuiModalFooter>
                           </div>
@@ -2075,7 +2082,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                         class="euiModalFooter"
                       >
                         <button
-                          class="euiButton euiButton--primary euiButton--fill"
+                          class="euiButton euiButton--primary euiButton--small euiButton--fill"
                           type="button"
                         >
                           <span
@@ -2370,7 +2377,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                 class="euiModalFooter"
                               >
                                 <button
-                                  class="euiButton euiButton--primary euiButton--fill"
+                                  class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                   type="button"
                                 >
                                   <span
@@ -2597,7 +2604,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                   class="euiModalFooter"
                                 >
                                   <button
-                                    class="euiButton euiButton--primary euiButton--fill"
+                                    class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                     type="button"
                                   >
                                     <span
@@ -2824,7 +2831,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                     class="euiModalFooter"
                                   >
                                     <button
-                                      class="euiButton euiButton--primary euiButton--fill"
+                                      class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                       type="button"
                                     >
                                       <span
@@ -3039,7 +3046,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                       class="euiModalFooter"
                                     >
                                       <button
-                                        class="euiButton euiButton--primary euiButton--fill"
+                                        class="euiButton euiButton--primary euiButton--small euiButton--fill"
                                         type="button"
                                       >
                                         <span
@@ -3560,52 +3567,59 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                               <div
                                 className="euiModalFooter"
                               >
-                                <EuiButton
+                                <EuiSmallButton
                                   fill={true}
                                   onClick={[MockFunction]}
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButton"
-                                    disabled={false}
-                                    element="button"
+                                  <EuiButton
                                     fill={true}
-                                    isDisabled={false}
                                     onClick={[MockFunction]}
-                                    type="button"
+                                    size="s"
                                   >
-                                    <button
-                                      className="euiButton euiButton--primary euiButton--fill"
+                                    <EuiButtonDisplay
+                                      baseClassName="euiButton"
                                       disabled={false}
+                                      element="button"
+                                      fill={true}
+                                      isDisabled={false}
                                       onClick={[MockFunction]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                      size="s"
                                       type="button"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
+                                      <button
+                                        className="euiButton euiButton--primary euiButton--small euiButton--fill"
+                                        disabled={false}
+                                        onClick={[MockFunction]}
+                                        style={
                                           Object {
-                                            "className": "euiButton__text",
+                                            "minWidth": undefined,
                                           }
                                         }
+                                        type="button"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
+                                        <EuiButtonContent
+                                          className="euiButton__content"
+                                          iconSide="left"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButton__text",
+                                            }
+                                          }
                                         >
                                           <span
-                                            className="euiButton__text"
+                                            className="euiButtonContent euiButton__content"
                                           >
-                                            Close
+                                            <span
+                                              className="euiButton__text"
+                                            >
+                                              Close
+                                            </span>
                                           </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonDisplay>
-                                </EuiButton>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonDisplay>
+                                  </EuiButton>
+                                </EuiSmallButton>
                               </div>
                             </EuiModalFooter>
                           </div>

--- a/public/pages/Channels/components/ChannelActions.tsx
+++ b/public/pages/Channels/components/ChannelActions.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiContextMenuItem, EuiPopover } from '@elastic/eui';
+import { EuiSmallButton, EuiContextMenuItem, EuiPopover } from '@elastic/eui';
 import React, { useContext, useState } from 'react';
 import { SERVER_DELAY } from '../../../../common';
 import { ChannelItemType } from '../../../../models/interfaces';
@@ -83,14 +83,14 @@ export function ChannelActions(props: ChannelActionsProps) {
         <EuiPopover
           panelPaddingSize="none"
           button={
-            <EuiButton
+            <EuiSmallButton
               iconType="arrowDown"
               iconSide="right"
               disabled={props.selected.length === 0}
               onClick={() => setIsPopoverOpen(!isPopoverOpen)}
             >
               Actions
-            </EuiButton>
+            </EuiSmallButton>
           }
           isOpen={isPopoverOpen}
           closePopover={() => setIsPopoverOpen(false)}

--- a/public/pages/Channels/components/ChannelControls.tsx
+++ b/public/pages/Channels/components/ChannelControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiFilterButton,
   EuiFilterGroup,
   EuiFilterSelectItem,
@@ -98,7 +98,7 @@ export const ChannelControls = (props: ChannelControlsProps) => {
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
-        <EuiFieldSearch
+        <EuiCompressedFieldSearch
           fullWidth={true}
           placeholder="Search"
           onSearch={props.onSearchChange}

--- a/public/pages/Channels/components/ChannelControls.tsx
+++ b/public/pages/Channels/components/ChannelControls.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiCompressedFieldSearch,
-  EuiFilterButton,
+  EuiSmallFilterButton,
   EuiFilterGroup,
   EuiFilterSelectItem,
   EuiFlexGroup,
@@ -109,13 +109,13 @@ export const ChannelControls = (props: ChannelControlsProps) => {
         <EuiFilterGroup>
           <EuiPopover
             button={
-              <EuiFilterButton
+              <EuiSmallFilterButton
                 iconType="arrowDown"
                 grow={false}
                 onClick={() => setIsStatePopoverOpen(!isStatePopoverOpen)}
               >
                 {isItemSelected(stateItems) ? <b>Status</b> : 'Status'}
-              </EuiFilterButton>
+              </EuiSmallFilterButton>
             }
             isOpen={isStatePopoverOpen}
             closePopover={() => setIsStatePopoverOpen(false)}
@@ -138,13 +138,13 @@ export const ChannelControls = (props: ChannelControlsProps) => {
           </EuiPopover>
           <EuiPopover
             button={
-              <EuiFilterButton
+              <EuiSmallFilterButton
                 iconType="arrowDown"
                 grow={false}
                 onClick={() => setIsTypePopoverOpen(!isTypePopoverOpen)}
               >
                 {isItemSelected(typeItems) ? <b>Type</b> : 'Type'}
-              </EuiFilterButton>
+              </EuiSmallFilterButton>
             }
             isOpen={isTypePopoverOpen}
             closePopover={() => setIsTypePopoverOpen(false)}

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -4,6 +4,7 @@
  */
 
 import {
+  EuiButton,
   EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiGlobalToastList,
@@ -164,7 +164,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
           {channel && (
             <ModalConsumer>
               {({ onShow }) => (
-                <EuiButton
+                <EuiSmallButton
                   data-test-subj="channel-details-mute-button"
                   iconType={channel?.is_enabled ? 'bellSlash' : 'bell'}
                   onClick={() => {
@@ -189,7 +189,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
                   }}
                 >
                   {channel?.is_enabled ? 'Mute channel' : 'Unmute channel'}
-                </EuiButton>
+                </EuiSmallButton>
               )}
             </ModalConsumer>
           )}

--- a/public/pages/Channels/components/details/ChannelDetailsActions.tsx
+++ b/public/pages/Channels/components/details/ChannelDetailsActions.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiPopover,
   EuiTextColor,
@@ -81,13 +81,13 @@ export function ChannelDetailsActions(props: ChannelDetailsActionsProps) {
         <EuiPopover
           panelPaddingSize="none"
           button={
-            <EuiButton
+            <EuiSmallButton
               iconType="arrowDown"
               iconSide="right"
               onClick={() => setIsPopoverOpen(!isPopoverOpen)}
             >
               Actions
-            </EuiButton>
+            </EuiSmallButton>
           }
           isOpen={isPopoverOpen}
           closePopover={() => setIsPopoverOpen(false)}

--- a/public/pages/Channels/components/modals/DeleteChannelModal.tsx
+++ b/public/pages/Channels/components/modals/DeleteChannelModal.tsx
@@ -6,7 +6,7 @@
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiModal,
@@ -69,7 +69,7 @@ export const DeleteChannelModal = (props: DeleteChannelModalProps) => {
           <EuiText>
             To confirm delete, type <i>delete</i> in the field.
           </EuiText>
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="delete"
             value={input}
             onChange={(e) => setInput(e.target.value)}

--- a/public/pages/Channels/components/modals/DeleteChannelModal.tsx
+++ b/public/pages/Channels/components/modals/DeleteChannelModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiFlexGroup,
@@ -81,7 +81,7 @@ export const DeleteChannelModal = (props: DeleteChannelModalProps) => {
               <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 fill
                 data-test-subj="delete-channel-modal-delete-button"
                 color="danger"
@@ -117,7 +117,7 @@ export const DeleteChannelModal = (props: DeleteChannelModalProps) => {
                 disabled={input !== 'delete'}
               >
                 Delete
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiModalFooter>

--- a/public/pages/Channels/components/modals/DeleteChannelModal.tsx
+++ b/public/pages/Channels/components/modals/DeleteChannelModal.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -78,7 +78,7 @@ export const DeleteChannelModal = (props: DeleteChannelModalProps) => {
         <EuiModalFooter>
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
+              <EuiSmallButtonEmpty onClick={props.onClose}>Cancel</EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/pages/Channels/components/modals/DetailsListModal.tsx
+++ b/public/pages/Channels/components/modals/DetailsListModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiHorizontalRule,
   EuiModal,
   EuiModalBody,
@@ -46,9 +46,9 @@ export function DetailsListModal(props: DetailsListModalProps) {
             })}
           </EuiModalBody>
           <EuiModalFooter>
-            <EuiButton fill onClick={props.onClose}>
+            <EuiSmallButton fill onClick={props.onClose}>
               Close
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       </EuiOverlayMask>

--- a/public/pages/Channels/components/modals/DetailsTableModal.tsx
+++ b/public/pages/Channels/components/modals/DetailsTableModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiInMemoryTable,
   EuiModal,
   EuiModalBody,
@@ -55,9 +55,9 @@ export function DetailsTableModal(props: DetailsTableModalProps) {
             <EuiInMemoryTable items={props.items} columns={columns} />
           </EuiModalBody>
           <EuiModalFooter>
-            <EuiButton fill onClick={props.onClose}>
+            <EuiSmallButton fill onClick={props.onClose}>
               Close
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       </EuiOverlayMask>

--- a/public/pages/Channels/components/modals/MuteChannelModal.tsx
+++ b/public/pages/Channels/components/modals/MuteChannelModal.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiModal,
@@ -48,7 +48,7 @@ export const MuteChannelModal = (props: MuteChannelModalProps) => {
         <EuiModalFooter>
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
+              <EuiSmallButtonEmpty onClick={props.onClose}>Cancel</EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/pages/Channels/components/modals/MuteChannelModal.tsx
+++ b/public/pages/Channels/components/modals/MuteChannelModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -51,7 +51,7 @@ export const MuteChannelModal = (props: MuteChannelModalProps) => {
               <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 fill
                 data-test-subj="mute-channel-modal-mute-button"
                 onClick={async () => {
@@ -75,7 +75,7 @@ export const MuteChannelModal = (props: MuteChannelModalProps) => {
                 }}
               >
                 Mute
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiModalFooter>

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiSpacer,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiSuperSelectOption,
   EuiText,
   EuiTitle,
@@ -391,7 +391,7 @@ export function CreateChannel(props: CreateChannelsProps) {
                 <EuiText size="xs" color="subdued">
                   Channel type cannot be changed after the channel is created.
                 </EuiText>
-                <EuiSuperSelect
+                <EuiCompressedSuperSelect
                   options={channelTypeOptions}
                   valueOfSelected={channelType}
                   onChange={setChannelType}

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -465,7 +465,7 @@ export function CreateChannel(props: CreateChannelsProps) {
             <EuiButtonEmpty href={prevURL}>Cancel</EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="create-channel-send-test-message-button"
               onClick={() => {
                 if (!isInputValid()) {
@@ -478,10 +478,10 @@ export function CreateChannel(props: CreateChannelsProps) {
               }}
             >
               Send test message
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               fill
               data-test-subj="create-channel-create-button"
               isLoading={loading}
@@ -523,7 +523,7 @@ export function CreateChannel(props: CreateChannelsProps) {
               }}
             >
               {props.edit ? 'Save' : 'Create'}
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </CreateChannelContext.Provider>

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -462,7 +462,7 @@ export function CreateChannel(props: CreateChannelsProps) {
         <EuiSpacer />
         <EuiFlexGroup gutterSize="m" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty href={prevURL}>Cancel</EuiButtonEmpty>
+            <EuiSmallButtonEmpty href={prevURL}>Cancel</EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -9,7 +9,7 @@ import {
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiSuperSelect,
   EuiSuperSelectOption,
@@ -383,7 +383,7 @@ export function CreateChannel(props: CreateChannelsProps) {
           title="Configurations"
           titleSize="s"
         >
-          <EuiFormRow label="Channel type">
+          <EuiCompressedFormRow label="Channel type">
             {props.edit ? (
               <EuiText size="s">{CHANNEL_TYPE[channelType]}</EuiText>
             ) : (
@@ -399,7 +399,7 @@ export function CreateChannel(props: CreateChannelsProps) {
                 />
               </>
             )}
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           {channelType === BACKEND_CHANNEL_TYPE.SLACK ? (
             <SlackSettings
               slackWebhook={slackWebhook}

--- a/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<ChannelNamePanel/> spec renders errors 1`] = `
     style="padding: initial;"
   >
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="random_html_id-row"
     >
       <div
@@ -43,14 +43,14 @@ exports[`<ChannelNamePanel/> spec renders errors 1`] = `
         class="euiFormRow__fieldWrapper"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
               aria-describedby="random_html_id-error-0"
-              class="euiFieldText"
+              class="euiFieldText euiFieldText--compressed"
               data-test-subj="create-channel-name-input"
               id="random_html_id"
               placeholder="Enter channel name"
@@ -69,7 +69,7 @@ exports[`<ChannelNamePanel/> spec renders errors 1`] = `
       </div>
     </div>
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="random_html_id-row"
     >
       <div
@@ -93,10 +93,10 @@ exports[`<ChannelNamePanel/> spec renders errors 1`] = `
         class="euiFormRow__fieldWrapper"
       >
         <textarea
-          class="euiTextArea euiTextArea--resizeVertical"
+          class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
           data-test-subj="create-channel-description-input"
           placeholder="What is the purpose of this channel?"
-          rows="6"
+          rows="3"
           style="height: 4.1rem;"
         >
           test description
@@ -132,7 +132,7 @@ exports[`<ChannelNamePanel/> spec renders the component 1`] = `
     style="padding: initial;"
   >
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="random_html_id-row"
     >
       <div
@@ -150,13 +150,13 @@ exports[`<ChannelNamePanel/> spec renders the component 1`] = `
         class="euiFormRow__fieldWrapper"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
-              class="euiFieldText"
+              class="euiFieldText euiFieldText--compressed"
               data-test-subj="create-channel-name-input"
               id="random_html_id"
               placeholder="Enter channel name"
@@ -168,7 +168,7 @@ exports[`<ChannelNamePanel/> spec renders the component 1`] = `
       </div>
     </div>
     <div
-      class="euiFormRow"
+      class="euiFormRow euiFormRow--compressed"
       id="random_html_id-row"
     >
       <div
@@ -192,10 +192,10 @@ exports[`<ChannelNamePanel/> spec renders the component 1`] = `
         class="euiFormRow__fieldWrapper"
       >
         <textarea
-          class="euiTextArea euiTextArea--resizeVertical"
+          class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
           data-test-subj="create-channel-description-input"
           placeholder="What is the purpose of this channel?"
-          rows="6"
+          rows="3"
           style="height: 4.1rem;"
         >
           test description

--- a/public/pages/CreateChannel/__tests__/__snapshots__/ChimeSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/ChimeSettings.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ChimeSettings /> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -21,13 +21,13 @@ exports[`<ChimeSettings /> spec renders the component 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-channel-chime-webhook-input"
           id="random_html_id"
           placeholder="https://hooks.chime.aws/incomingwebhooks/XXXXX..."
@@ -42,7 +42,7 @@ exports[`<ChimeSettings /> spec renders the component 1`] = `
 
 exports[`<ChimeSettings /> spec renders the component with error 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -61,14 +61,14 @@ exports[`<ChimeSettings /> spec renders the component with error 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-error-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-channel-chime-webhook-input"
           id="random_html_id"
           placeholder="https://hooks.chime.aws/incomingwebhooks/XXXXX..."

--- a/public/pages/CreateChannel/__tests__/__snapshots__/CustomWebhookSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/CustomWebhookSettings.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<CustomWebhookSettings /> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -32,7 +32,7 @@ exports[`<CustomWebhookSettings /> spec renders the component 1`] = `
             value=""
           />
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
@@ -46,7 +46,7 @@ exports[`<CustomWebhookSettings /> spec renders the component 1`] = `
               <button
                 aria-haspopup="true"
                 aria-labelledby="random_html_id random_html_id"
-                class="euiSuperSelectControl"
+                class="euiSuperSelectControl euiSuperSelectControl--compressed"
                 type="button"
               />
               <div
@@ -57,7 +57,7 @@ exports[`<CustomWebhookSettings /> spec renders the component 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                    class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                     focusable="false"
                     height="16"
                     role="img"
@@ -82,7 +82,7 @@ exports[`<CustomWebhookSettings /> spec renders the component 1`] = `
 
 exports[`<CustomWebhookSettings /> spec renders the component 2`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -112,7 +112,7 @@ exports[`<CustomWebhookSettings /> spec renders the component 2`] = `
             value=""
           />
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
@@ -126,7 +126,7 @@ exports[`<CustomWebhookSettings /> spec renders the component 2`] = `
               <button
                 aria-haspopup="true"
                 aria-labelledby="random_html_id random_html_id"
-                class="euiSuperSelectControl"
+                class="euiSuperSelectControl euiSuperSelectControl--compressed"
                 type="button"
               />
               <div
@@ -137,7 +137,7 @@ exports[`<CustomWebhookSettings /> spec renders the component 2`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                    class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                     focusable="false"
                     height="16"
                     role="img"
@@ -162,7 +162,7 @@ exports[`<CustomWebhookSettings /> spec renders the component 2`] = `
 
 exports[`<CustomWebhookSettings /> spec renders the component with errors 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -192,7 +192,7 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 1`] = 
             value=""
           />
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
@@ -206,7 +206,7 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 1`] = 
               <button
                 aria-haspopup="true"
                 aria-labelledby="random_html_id random_html_id"
-                class="euiSuperSelectControl"
+                class="euiSuperSelectControl euiSuperSelectControl--compressed"
                 type="button"
               />
               <div
@@ -217,7 +217,7 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 1`] = 
                 >
                   <svg
                     aria-hidden="true"
-                    class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                    class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                     focusable="false"
                     height="16"
                     role="img"
@@ -243,7 +243,7 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 1`] = 
 
 exports[`<CustomWebhookSettings /> spec renders the component with errors 2`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -273,7 +273,7 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 2`] = 
             value=""
           />
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--compressed"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
@@ -287,7 +287,7 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 2`] = 
               <button
                 aria-haspopup="true"
                 aria-labelledby="random_html_id random_html_id"
-                class="euiSuperSelectControl"
+                class="euiSuperSelectControl euiSuperSelectControl--compressed"
                 type="button"
               />
               <div
@@ -298,7 +298,7 @@ exports[`<CustomWebhookSettings /> spec renders the component with errors 2`] = 
                 >
                   <svg
                     aria-hidden="true"
-                    class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                    class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                     focusable="false"
                     height="16"
                     role="img"

--- a/public/pages/CreateChannel/__tests__/__snapshots__/MicrosoftTeamsSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/MicrosoftTeamsSettings.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<MicrosoftTeamsSettings /> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -21,13 +21,13 @@ exports[`<MicrosoftTeamsSettings /> spec renders the component 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-channel-microsoftTeams-webhook-input"
           id="random_html_id"
           placeholder="https://xxxxx.webhook.office.com/webhookb2/xxxxx/IncomingWebhook/xxxxx..."
@@ -42,7 +42,7 @@ exports[`<MicrosoftTeamsSettings /> spec renders the component 1`] = `
 
 exports[`<MicrosoftTeamsSettings /> spec renders the component with error 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -61,14 +61,14 @@ exports[`<MicrosoftTeamsSettings /> spec renders the component with error 1`] = 
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-error-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-channel-microsoftTeams-webhook-input"
           id="random_html_id"
           placeholder="https://xxxxx.webhook.office.com/webhookb2/xxxxx/IncomingWebhook/xxxxx..."

--- a/public/pages/CreateChannel/__tests__/__snapshots__/SlackSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/SlackSettings.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SlackSettings /> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -21,13 +21,13 @@ exports[`<SlackSettings /> spec renders the component 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-channel-slack-webhook-input"
           id="random_html_id"
           placeholder="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX..."
@@ -42,7 +42,7 @@ exports[`<SlackSettings /> spec renders the component 1`] = `
 
 exports[`<SlackSettings /> spec renders the component with error 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 700px;"
 >
@@ -61,14 +61,14 @@ exports[`<SlackSettings /> spec renders the component with error 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-error-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-channel-slack-webhook-input"
           id="random_html_id"
           placeholder="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX..."

--- a/public/pages/CreateChannel/components/ChannelNamePanel.tsx
+++ b/public/pages/CreateChannel/components/ChannelNamePanel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiFormRow, EuiTextArea } from '@elastic/eui';
+import { EuiFieldText, EuiCompressedFormRow, EuiTextArea } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { ContentPanel } from '../../../components/ContentPanel';
 import { CreateChannelContext } from '../CreateChannel';
@@ -25,7 +25,7 @@ export function ChannelNamePanel(props: ChannelNamePanelProps) {
         title="Name and description"
         titleSize="s"
       >
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="Name"
           error={context.inputErrors.name.join(' ')}
           isInvalid={context.inputErrors.name.length > 0}
@@ -43,8 +43,8 @@ export function ChannelNamePanel(props: ChannelNamePanelProps) {
               });
             }}
           />
-        </EuiFormRow>
-        <EuiFormRow
+        </EuiCompressedFormRow>
+        <EuiCompressedFormRow
           label={
             <span>
               Description - <i style={{ fontWeight: 'normal' }}>optional</i>
@@ -60,7 +60,7 @@ export function ChannelNamePanel(props: ChannelNamePanelProps) {
               onChange={(e) => props.setDescription(e.target.value)}
             />
           </>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </ContentPanel>
     </>
   );

--- a/public/pages/CreateChannel/components/ChannelNamePanel.tsx
+++ b/public/pages/CreateChannel/components/ChannelNamePanel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCompressedFieldText, EuiCompressedFormRow, EuiTextArea } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiCompressedFormRow, EuiCompressedTextArea } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { ContentPanel } from '../../../components/ContentPanel';
 import { CreateChannelContext } from '../CreateChannel';
@@ -52,7 +52,7 @@ export function ChannelNamePanel(props: ChannelNamePanelProps) {
           }
         >
           <>
-            <EuiTextArea
+            <EuiCompressedTextArea
               data-test-subj="create-channel-description-input"
               placeholder="What is the purpose of this channel?"
               style={{ height: '4.1rem' }}

--- a/public/pages/CreateChannel/components/ChannelNamePanel.tsx
+++ b/public/pages/CreateChannel/components/ChannelNamePanel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiCompressedFormRow, EuiTextArea } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiCompressedFormRow, EuiTextArea } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { ContentPanel } from '../../../components/ContentPanel';
 import { CreateChannelContext } from '../CreateChannel';
@@ -30,7 +30,7 @@ export function ChannelNamePanel(props: ChannelNamePanelProps) {
           error={context.inputErrors.name.join(' ')}
           isInvalid={context.inputErrors.name.length > 0}
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             data-test-subj="create-channel-name-input"
             placeholder="Enter channel name"
             value={props.name}

--- a/public/pages/CreateChannel/components/ChimeSettings.tsx
+++ b/public/pages/CreateChannel/components/ChimeSettings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiCompressedFormRow } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiCompressedFormRow } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CreateChannelContext } from '../CreateChannel';
 import { validateWebhookURL } from '../utils/validationHelper';
@@ -23,7 +23,7 @@ export function ChimeSettings(props: ChimeSettingsProps) {
       error={context.inputErrors.chimeWebhook.join(' ')}
       isInvalid={context.inputErrors.chimeWebhook.length > 0}
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         fullWidth
         data-test-subj="create-channel-chime-webhook-input"
         placeholder="https://hooks.chime.aws/incomingwebhooks/XXXXX..."

--- a/public/pages/CreateChannel/components/ChimeSettings.tsx
+++ b/public/pages/CreateChannel/components/ChimeSettings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiFormRow } from '@elastic/eui';
+import { EuiFieldText, EuiCompressedFormRow } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CreateChannelContext } from '../CreateChannel';
 import { validateWebhookURL } from '../utils/validationHelper';
@@ -17,7 +17,7 @@ export function ChimeSettings(props: ChimeSettingsProps) {
   const context = useContext(CreateChannelContext)!;
 
   return (
-    <EuiFormRow
+    <EuiCompressedFormRow
       label="Webhook URL"
       style={{ maxWidth: '700px' }}
       error={context.inputErrors.chimeWebhook.join(' ')}
@@ -37,6 +37,6 @@ export function ChimeSettings(props: ChimeSettingsProps) {
           });
         }}
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 }

--- a/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
+++ b/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
@@ -10,7 +10,7 @@ import {
   EuiRadioGroup,
   EuiRadioGroupOption,
   EuiSpacer,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
 } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CUSTOM_WEBHOOK_ENDPOINT_TYPE } from '../../../utils/constants';
@@ -87,7 +87,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
     return (
       <>
         <EuiCompressedFormRow label="Type">
-          <EuiSuperSelect
+          <EuiCompressedSuperSelect
             options={[
               { value: 'HTTPS', inputDisplay: 'HTTPS' },
               { value: 'HTTP', inputDisplay: 'HTTP' },
@@ -166,7 +166,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
   return (
     <>
       <EuiCompressedFormRow label="Method" style={{ maxWidth: '700px' }}>
-        <EuiSuperSelect
+        <EuiCompressedSuperSelect
           options={[
             { value: 'POST', inputDisplay: 'POST' },
             { value: 'PUT', inputDisplay: 'PUT' },

--- a/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
+++ b/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
@@ -4,8 +4,8 @@
  */
 
 import {
-  EuiFieldNumber,
-  EuiFieldText,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
   EuiCompressedFormRow,
   EuiRadioGroup,
   EuiRadioGroupOption,
@@ -66,7 +66,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
         error={context.inputErrors.webhookURL.join(' ')}
         isInvalid={context.inputErrors.webhookURL.length > 0}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           placeholder="https://name.example.com/XXXXX..."
           data-test-subj="custom-webhook-url-input"
           value={props.webhookURL}
@@ -101,7 +101,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
           error={context.inputErrors.customURLHost.join(' ')}
           isInvalid={context.inputErrors.customURLHost.length > 0}
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="name.example.com"
             data-test-subj="custom-webhook-host-input"
             value={props.customURLHost}
@@ -124,7 +124,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
           error={context.inputErrors.customURLPort.join(' ')}
           isInvalid={context.inputErrors.customURLPort.length > 0}
         >
-          <EuiFieldNumber
+          <EuiCompressedFieldNumber
             placeholder="Enter port"
             data-test-subj="custom-webhook-port-input"
             value={props.customURLPort}
@@ -145,7 +145,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
             </span>
           }
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="Enter path"
             data-test-subj="custom-webhook-path-input"
             value={props.customURLPath}

--- a/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
+++ b/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
@@ -7,7 +7,7 @@ import {
   EuiCompressedFieldNumber,
   EuiCompressedFieldText,
   EuiCompressedFormRow,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiRadioGroupOption,
   EuiSpacer,
   EuiCompressedSuperSelect,
@@ -178,7 +178,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
       </EuiCompressedFormRow>
 
       <EuiCompressedFormRow label="Define endpoints by" style={{ maxWidth: '700px' }}>
-        <EuiRadioGroup
+        <EuiCompressedRadioGroup
           options={webhookTypeOptions}
           idSelected={props.webhookTypeIdSelected}
           onChange={(id: string) =>

--- a/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
+++ b/public/pages/CreateChannel/components/CustomWebhookSettings.tsx
@@ -6,7 +6,7 @@
 import {
   EuiFieldNumber,
   EuiFieldText,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiRadioGroup,
   EuiRadioGroupOption,
   EuiSpacer,
@@ -61,7 +61,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
 
   const renderWebhook = () => {
     return (
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Webhook URL"
         error={context.inputErrors.webhookURL.join(' ')}
         isInvalid={context.inputErrors.webhookURL.length > 0}
@@ -79,14 +79,14 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
             });
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
 
   const renderCustomURL = () => {
     return (
       <>
-        <EuiFormRow label="Type">
+        <EuiCompressedFormRow label="Type">
           <EuiSuperSelect
             options={[
               { value: 'HTTPS', inputDisplay: 'HTTPS' },
@@ -95,8 +95,8 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
             valueOfSelected={props.customURLType}
             onChange={props.setCustomURLType}
           />
-        </EuiFormRow>
-        <EuiFormRow
+        </EuiCompressedFormRow>
+        <EuiCompressedFormRow
           label="Host"
           error={context.inputErrors.customURLHost.join(' ')}
           isInvalid={context.inputErrors.customURLHost.length > 0}
@@ -114,8 +114,8 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
               });
             }}
           />
-        </EuiFormRow>
-        <EuiFormRow
+        </EuiCompressedFormRow>
+        <EuiCompressedFormRow
           label={
             <span>
               Port - <i style={{ fontWeight: 'normal' }}>optional</i>
@@ -137,8 +137,8 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
               });
             }}
           />
-        </EuiFormRow>
-        <EuiFormRow
+        </EuiCompressedFormRow>
+        <EuiCompressedFormRow
           label={
             <span>
               Path - <i style={{ fontWeight: 'normal' }}>optional</i>
@@ -151,7 +151,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
             value={props.customURLPath}
             onChange={(e) => props.setCustomURLPath(e.target.value)}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
         <EuiSpacer />
         <WebhookHeaders
@@ -165,7 +165,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
 
   return (
     <>
-      <EuiFormRow label="Method" style={{ maxWidth: '700px' }}>
+      <EuiCompressedFormRow label="Method" style={{ maxWidth: '700px' }}>
         <EuiSuperSelect
           options={[
             { value: 'POST', inputDisplay: 'POST' },
@@ -175,9 +175,9 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
           valueOfSelected={props.webhookMethod}
           onChange={props.setWebhookMethod}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
-      <EuiFormRow label="Define endpoints by" style={{ maxWidth: '700px' }}>
+      <EuiCompressedFormRow label="Define endpoints by" style={{ maxWidth: '700px' }}>
         <EuiRadioGroup
           options={webhookTypeOptions}
           idSelected={props.webhookTypeIdSelected}
@@ -187,7 +187,7 @@ export function CustomWebhookSettings(props: CustomWebhookSettingsProps) {
             )
           }
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       {props.webhookTypeIdSelected === 'WEBHOOK_URL'
         ? renderWebhook()
         : renderCustomURL()}

--- a/public/pages/CreateChannel/components/EmailSettings.tsx
+++ b/public/pages/CreateChannel/components/EmailSettings.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -187,7 +187,7 @@ export function EmailSettings(props: EmailSettingsProps) {
               <EuiFormRow hasEmptyLabelSpace>
                 <ModalConsumer>
                   {({ onShow }) => (
-                    <EuiButton
+                    <EuiSmallButton
                       onClick={() =>
                         onShow(CreateSESSenderModal, {
                           addSenderOptionAndSelect: (
@@ -207,7 +207,7 @@ export function EmailSettings(props: EmailSettingsProps) {
                       }
                     >
                       Create SES sender
-                    </EuiButton>
+                    </EuiSmallButton>
                   )}
                 </ModalConsumer>
               </EuiFormRow>
@@ -249,7 +249,7 @@ export function EmailSettings(props: EmailSettingsProps) {
               <EuiFormRow hasEmptyLabelSpace>
                 <ModalConsumer>
                   {({ onShow }) => (
-                    <EuiButton
+                    <EuiSmallButton
                       onClick={() =>
                         onShow(CreateSenderModal, {
                           addSenderOptionAndSelect: (
@@ -269,7 +269,7 @@ export function EmailSettings(props: EmailSettingsProps) {
                       }
                     >
                       Create SMTP sender
-                    </EuiButton>
+                    </EuiSmallButton>
                   )}
                 </ModalConsumer>
               </EuiFormRow>
@@ -325,7 +325,7 @@ export function EmailSettings(props: EmailSettingsProps) {
           <EuiFormRow hasEmptyLabelSpace>
             <ModalConsumer>
               {({ onShow }) => (
-                <EuiButton
+                <EuiSmallButton
                   onClick={() =>
                     onShow(CreateRecipientGroupModal, {
                       addRecipientGroupOptionAndSelect: (
@@ -348,7 +348,7 @@ export function EmailSettings(props: EmailSettingsProps) {
                   }
                 >
                   Create recipient group
-                </EuiButton>
+                </EuiSmallButton>
               )}
             </ModalConsumer>
           </EuiFormRow>

--- a/public/pages/CreateChannel/components/EmailSettings.tsx
+++ b/public/pages/CreateChannel/components/EmailSettings.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiSpacer,
   SortDirection,
 } from '@elastic/eui';
@@ -135,7 +135,7 @@ export function EmailSettings(props: EmailSettingsProps) {
     <>
       {smtpAvailable && (
         <EuiCompressedFormRow label="Sender type">
-          <EuiRadioGroup
+          <EuiCompressedRadioGroup
             options={[
               {
                 id: 'smtp_account',

--- a/public/pages/CreateChannel/components/EmailSettings.tsx
+++ b/public/pages/CreateChannel/components/EmailSettings.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -163,7 +163,7 @@ export function EmailSettings(props: EmailSettingsProps) {
                 error={context.inputErrors.sesSender.join(' ')}
                 isInvalid={context.inputErrors.sesSender.length > 0}
               >
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder="Sender name"
                   fullWidth
                   singleSelection
@@ -225,7 +225,7 @@ export function EmailSettings(props: EmailSettingsProps) {
                 error={context.inputErrors.smtpSender.join(' ')}
                 isInvalid={context.inputErrors.smtpSender.length > 0}
               >
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder="Sender name"
                   fullWidth
                   singleSelection
@@ -286,7 +286,7 @@ export function EmailSettings(props: EmailSettingsProps) {
             error={context.inputErrors.recipients.join(' ')}
             isInvalid={context.inputErrors.recipients.length > 0}
           >
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Email address, recipient group name"
               fullWidth
               options={recipientGroupOptions}

--- a/public/pages/CreateChannel/components/EmailSettings.tsx
+++ b/public/pages/CreateChannel/components/EmailSettings.tsx
@@ -9,7 +9,7 @@ import {
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiRadioGroup,
   EuiSpacer,
   SortDirection,
@@ -134,7 +134,7 @@ export function EmailSettings(props: EmailSettingsProps) {
   return (
     <>
       {smtpAvailable && (
-        <EuiFormRow label="Sender type">
+        <EuiCompressedFormRow label="Sender type">
           <EuiRadioGroup
             options={[
               {
@@ -150,14 +150,14 @@ export function EmailSettings(props: EmailSettingsProps) {
             onChange={(id) => props.setSenderType(id as SenderType)}
             name="sender type radio group"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
       {props.senderType === 'ses_account' ? (
         <>
           <EuiSpacer size="m" />
           <EuiFlexGroup>
             <EuiFlexItem style={{ maxWidth: 400 }}>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label="SES sender"
                 helpText={`A destination only allows one SES sender. Use "Create SES sender" to create a sender with its email address, IAM role, AWS region.`}
                 error={context.inputErrors.sesSender.join(' ')}
@@ -181,10 +181,10 @@ export function EmailSettings(props: EmailSettingsProps) {
                     });
                   }}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiFormRow hasEmptyLabelSpace>
+              <EuiCompressedFormRow hasEmptyLabelSpace>
                 <ModalConsumer>
                   {({ onShow }) => (
                     <EuiSmallButton
@@ -210,7 +210,7 @@ export function EmailSettings(props: EmailSettingsProps) {
                     </EuiSmallButton>
                   )}
                 </ModalConsumer>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>
         </>
@@ -219,7 +219,7 @@ export function EmailSettings(props: EmailSettingsProps) {
           <EuiSpacer size="m" />
           <EuiFlexGroup>
             <EuiFlexItem style={{ maxWidth: 400 }}>
-              <EuiFormRow
+              <EuiCompressedFormRow
                 label="SMTP sender"
                 helpText={`A destination only allows one SMTP sender. Use "Create SMTP sender" to create a sender with its email address, host, port, encryption method.`}
                 error={context.inputErrors.smtpSender.join(' ')}
@@ -243,10 +243,10 @@ export function EmailSettings(props: EmailSettingsProps) {
                     });
                   }}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiFormRow hasEmptyLabelSpace>
+              <EuiCompressedFormRow hasEmptyLabelSpace>
                 <ModalConsumer>
                   {({ onShow }) => (
                     <EuiSmallButton
@@ -272,7 +272,7 @@ export function EmailSettings(props: EmailSettingsProps) {
                     </EuiSmallButton>
                   )}
                 </ModalConsumer>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>
         </>
@@ -280,7 +280,7 @@ export function EmailSettings(props: EmailSettingsProps) {
 
       <EuiFlexGroup>
         <EuiFlexItem style={{ maxWidth: 400 }}>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Default recipients"
             helpText={`Add recipient(s) using an email address or pre-created email group. Use "Create email group" to create an email group.`}
             error={context.inputErrors.recipients.join(' ')}
@@ -319,10 +319,10 @@ export function EmailSettings(props: EmailSettingsProps) {
                 });
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiFormRow hasEmptyLabelSpace>
+          <EuiCompressedFormRow hasEmptyLabelSpace>
             <ModalConsumer>
               {({ onShow }) => (
                 <EuiSmallButton
@@ -351,7 +351,7 @@ export function EmailSettings(props: EmailSettingsProps) {
                 </EuiSmallButton>
               )}
             </ModalConsumer>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/CreateChannel/components/MicrosoftTeamsSettings.tsx
+++ b/public/pages/CreateChannel/components/MicrosoftTeamsSettings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiFormRow } from '@elastic/eui';
+import { EuiFieldText, EuiCompressedFormRow } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CreateChannelContext } from '../CreateChannel';
 import { validateWebhookURL } from '../utils/validationHelper';
@@ -17,7 +17,7 @@ export function MicrosoftTeamsSettings(props: MicrosoftTeamsSettingsProps) {
   const context = useContext(CreateChannelContext)!;
 
   return (
-    <EuiFormRow
+    <EuiCompressedFormRow
       label="Webhook URL"
       style={{ maxWidth: '700px' }}
       error={context.inputErrors.microsoftTeamsWebhook.join(' ')}
@@ -37,6 +37,6 @@ export function MicrosoftTeamsSettings(props: MicrosoftTeamsSettingsProps) {
           });
         }}
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 }

--- a/public/pages/CreateChannel/components/MicrosoftTeamsSettings.tsx
+++ b/public/pages/CreateChannel/components/MicrosoftTeamsSettings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiCompressedFormRow } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiCompressedFormRow } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CreateChannelContext } from '../CreateChannel';
 import { validateWebhookURL } from '../utils/validationHelper';
@@ -23,7 +23,7 @@ export function MicrosoftTeamsSettings(props: MicrosoftTeamsSettingsProps) {
       error={context.inputErrors.microsoftTeamsWebhook.join(' ')}
       isInvalid={context.inputErrors.microsoftTeamsWebhook.length > 0}
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         fullWidth
         data-test-subj="create-channel-microsoftTeams-webhook-input"
         placeholder="https://xxxxx.webhook.office.com/webhookb2/xxxxx/IncomingWebhook/xxxxx..."

--- a/public/pages/CreateChannel/components/SNSSettings.tsx
+++ b/public/pages/CreateChannel/components/SNSSettings.tsx
@@ -6,7 +6,7 @@
 import {
   EuiCallOut,
   EuiFieldText,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiSpacer,
   EuiText,
@@ -30,7 +30,7 @@ export function SNSSettings(props: SNSSettingsProps) {
   return (
     <>
       <EuiSpacer />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="SNS topic ARN"
         error={context.inputErrors.topicArn.join(' ')}
         isInvalid={context.inputErrors.topicArn.length > 0}
@@ -48,11 +48,11 @@ export function SNSSettings(props: SNSSettingsProps) {
             });
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       {mainStateContext.tooltipSupport ? (
         <>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label={
               <span>
                 IAM role ARN - <i style={{ fontWeight: 'normal' }}>optional</i>
@@ -72,7 +72,7 @@ export function SNSSettings(props: SNSSettingsProps) {
                 onChange={(e) => props.setRoleArn(e.target.value)}
               />
             </>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer />
           <EuiCallOut
             title="Using Amazon SNS outside of AWS"
@@ -88,7 +88,7 @@ export function SNSSettings(props: SNSSettingsProps) {
           </EuiCallOut>
         </>
       ) : (
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="IAM role ARN"
           error={context.inputErrors.roleArn.join(' ')}
           isInvalid={context.inputErrors.roleArn.length > 0}
@@ -106,7 +106,7 @@ export function SNSSettings(props: SNSSettingsProps) {
               });
             }}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
     </>
   );

--- a/public/pages/CreateChannel/components/SNSSettings.tsx
+++ b/public/pages/CreateChannel/components/SNSSettings.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiCallOut,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiCompressedFormRow,
   EuiLink,
   EuiSpacer,
@@ -35,7 +35,7 @@ export function SNSSettings(props: SNSSettingsProps) {
         error={context.inputErrors.topicArn.join(' ')}
         isInvalid={context.inputErrors.topicArn.length > 0}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           placeholder="ARN key"
           data-test-subj="sns-settings-topic-arn-input"
           value={props.topicArn}
@@ -65,7 +65,7 @@ export function SNSSettings(props: SNSSettingsProps) {
                 network.
               </EuiText>
               <EuiSpacer size="s" />
-              <EuiFieldText
+              <EuiCompressedFieldText
                 data-test-subj="sns-settings-role-arn-input"
                 placeholder="ARN key"
                 value={props.roleArn}
@@ -93,7 +93,7 @@ export function SNSSettings(props: SNSSettingsProps) {
           error={context.inputErrors.roleArn.join(' ')}
           isInvalid={context.inputErrors.roleArn.length > 0}
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="ARN key"
             data-test-subj="sns-settings-role-arn-input"
             value={props.roleArn}

--- a/public/pages/CreateChannel/components/SlackSettings.tsx
+++ b/public/pages/CreateChannel/components/SlackSettings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiFormRow } from '@elastic/eui';
+import { EuiFieldText, EuiCompressedFormRow } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CreateChannelContext } from '../CreateChannel';
 import { validateWebhookURL } from '../utils/validationHelper';
@@ -17,7 +17,7 @@ export function SlackSettings(props: SlackSettingsProps) {
   const context = useContext(CreateChannelContext)!;
 
   return (
-    <EuiFormRow
+    <EuiCompressedFormRow
       label="Slack webhook URL"
       style={{ maxWidth: '700px' }}
       error={context.inputErrors.slackWebhook.join(' ')}
@@ -37,6 +37,6 @@ export function SlackSettings(props: SlackSettingsProps) {
           });
         }}
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 }

--- a/public/pages/CreateChannel/components/SlackSettings.tsx
+++ b/public/pages/CreateChannel/components/SlackSettings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFieldText, EuiCompressedFormRow } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiCompressedFormRow } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { CreateChannelContext } from '../CreateChannel';
 import { validateWebhookURL } from '../utils/validationHelper';
@@ -23,7 +23,7 @@ export function SlackSettings(props: SlackSettingsProps) {
       error={context.inputErrors.slackWebhook.join(' ')}
       isInvalid={context.inputErrors.slackWebhook.length > 0}
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         fullWidth
         data-test-subj="create-channel-slack-webhook-input"
         placeholder="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX..."

--- a/public/pages/CreateChannel/components/WebhookHeaders.tsx
+++ b/public/pages/CreateChannel/components/WebhookHeaders.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -58,7 +58,7 @@ export function WebhookHeaders(props: WebhookHeadersProps) {
             <EuiFlexGroup style={{ maxWidth: 639 }}>
               <EuiFlexItem>
                 <EuiCompressedFormRow label="Key">
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     placeholder=""
                     value={header.key}
                     onChange={(e) => setHeader(e.target.value, null, i)}
@@ -72,7 +72,7 @@ export function WebhookHeaders(props: WebhookHeadersProps) {
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiCompressedFormRow label="Value">
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     placeholder=""
                     value={header.value}
                     onChange={(e) => setHeader(null, e.target.value, i)}

--- a/public/pages/CreateChannel/components/WebhookHeaders.tsx
+++ b/public/pages/CreateChannel/components/WebhookHeaders.tsx
@@ -8,7 +8,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -57,7 +57,7 @@ export function WebhookHeaders(props: WebhookHeadersProps) {
             <EuiSpacer size="s" />
             <EuiFlexGroup style={{ maxWidth: 639 }}>
               <EuiFlexItem>
-                <EuiFormRow label="Key">
+                <EuiCompressedFormRow label="Key">
                   <EuiFieldText
                     placeholder=""
                     value={header.key}
@@ -68,19 +68,19 @@ export function WebhookHeaders(props: WebhookHeadersProps) {
                       header.key === 'Content-Type'
                     } // first header needs to be Content-Type
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiFormRow label="Value">
+                <EuiCompressedFormRow label="Value">
                   <EuiFieldText
                     placeholder=""
                     value={header.value}
                     onChange={(e) => setHeader(null, e.target.value, i)}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiFormRow hasEmptyLabelSpace>
+                <EuiCompressedFormRow hasEmptyLabelSpace>
                   <EuiSmallButton
                     onClick={() => {
                       const newHeaders = [...props.headers];
@@ -95,7 +95,7 @@ export function WebhookHeaders(props: WebhookHeadersProps) {
                   >
                     {`Remove ${props.type}`}
                   </EuiSmallButton>
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
             </EuiFlexGroup>
           </div>

--- a/public/pages/CreateChannel/components/WebhookHeaders.tsx
+++ b/public/pages/CreateChannel/components/WebhookHeaders.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -81,7 +81,7 @@ export function WebhookHeaders(props: WebhookHeadersProps) {
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFormRow hasEmptyLabelSpace>
-                  <EuiButton
+                  <EuiSmallButton
                     onClick={() => {
                       const newHeaders = [...props.headers];
                       newHeaders.splice(i, 1);
@@ -94,7 +94,7 @@ export function WebhookHeaders(props: WebhookHeadersProps) {
                     }
                   >
                     {`Remove ${props.type}`}
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFormRow>
               </EuiFlexItem>
             </EuiFlexGroup>
@@ -103,13 +103,13 @@ export function WebhookHeaders(props: WebhookHeadersProps) {
       })}
 
       <EuiSpacer size="m" />
-      <EuiButton
+      <EuiSmallButton
         onClick={() => {
           props.setHeaders([...props.headers, { key: '', value: '' }]);
         }}
       >
         {`Add ${props.type}`}
-      </EuiButton>
+      </EuiSmallButton>
     </>
   );
 }

--- a/public/pages/CreateChannel/components/modals/CreateRecipientGroupModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateRecipientGroupModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBoxOptionOption,
   EuiModal,
@@ -86,7 +86,7 @@ export function CreateRecipientGroupModal(
 
         <EuiModalFooter>
           <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="create-recipient-group-modal-create-button"
             fill
             onClick={async () => {
@@ -121,7 +121,7 @@ export function CreateRecipientGroupModal(
             }}
           >
             Create
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/pages/CreateChannel/components/modals/CreateRecipientGroupModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateRecipientGroupModal.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiComboBoxOptionOption,
   EuiModal,
   EuiModalBody,
@@ -85,7 +85,7 @@ export function CreateRecipientGroupModal(
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={props.onClose}>Cancel</EuiSmallButtonEmpty>
           <EuiSmallButton
             data-test-subj="create-recipient-group-modal-create-button"
             fill

--- a/public/pages/CreateChannel/components/modals/CreateSESSenderModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateSESSenderModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBoxOptionOption,
   EuiModal,
@@ -90,7 +90,7 @@ export function CreateSESSenderModal(props: CreateSESSenderModalProps) {
 
         <EuiModalFooter>
           <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="create-ses-sender-modal-create-button"
             fill
             onClick={async () => {
@@ -126,7 +126,7 @@ export function CreateSESSenderModal(props: CreateSESSenderModalProps) {
             }}
           >
             Create
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/pages/CreateChannel/components/modals/CreateSESSenderModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateSESSenderModal.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiComboBoxOptionOption,
   EuiModal,
   EuiModalBody,
@@ -89,7 +89,7 @@ export function CreateSESSenderModal(props: CreateSESSenderModalProps) {
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={props.onClose}>Cancel</EuiSmallButtonEmpty>
           <EuiSmallButton
             data-test-subj="create-ses-sender-modal-create-button"
             fill

--- a/public/pages/CreateChannel/components/modals/CreateSenderModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateSenderModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBoxOptionOption,
   EuiModal,
@@ -90,7 +90,7 @@ export function CreateSenderModal(props: CreateSenderModalProps) {
 
         <EuiModalFooter>
           <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="create-sender-modal-create-button"
             fill
             onClick={async () => {
@@ -127,7 +127,7 @@ export function CreateSenderModal(props: CreateSenderModalProps) {
             }}
           >
             Create
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/pages/CreateChannel/components/modals/CreateSenderModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateSenderModal.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiComboBoxOptionOption,
   EuiModal,
   EuiModalBody,
@@ -89,7 +89,7 @@ export function CreateSenderModal(props: CreateSenderModalProps) {
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={props.onClose}>Cancel</EuiSmallButtonEmpty>
           <EuiSmallButton
             data-test-subj="create-sender-modal-create-button"
             fill

--- a/public/pages/Emails/CreateRecipientGroup.tsx
+++ b/public/pages/Emails/CreateRecipientGroup.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -130,9 +130,9 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
       <EuiSpacer />
       <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty href={`#${ROUTES.EMAIL_GROUPS}`}>
+          <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_GROUPS}`}>
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton

--- a/public/pages/Emails/CreateRecipientGroup.tsx
+++ b/public/pages/Emails/CreateRecipientGroup.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -135,7 +135,7 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             isLoading={loading}
             onClick={async () => {
@@ -183,7 +183,7 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
             }}
           >
             {props.edit ? 'Save' : 'Create'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/Emails/CreateSESSender.tsx
+++ b/public/pages/Emails/CreateSESSender.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -134,7 +134,7 @@ export function CreateSESSender(props: CreateSESSenderProps) {
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             isLoading={loading}
             onClick={async () => {
@@ -180,7 +180,7 @@ export function CreateSESSender(props: CreateSESSenderProps) {
             }}
           >
             {props.edit ? 'Save' : 'Create'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/Emails/CreateSESSender.tsx
+++ b/public/pages/Emails/CreateSESSender.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -129,9 +129,9 @@ export function CreateSESSender(props: CreateSESSenderProps) {
       <EuiSpacer />
       <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty href={`#${ROUTES.EMAIL_SENDERS}`}>
+          <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_SENDERS}`}>
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton

--- a/public/pages/Emails/CreateSender.tsx
+++ b/public/pages/Emails/CreateSender.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -133,7 +133,7 @@ export function CreateSender(props: CreateSenderProps) {
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             isLoading={loading}
             onClick={async () => {
@@ -180,7 +180,7 @@ export function CreateSender(props: CreateSenderProps) {
             }}
           >
             {props.edit ? 'Save' : 'Create'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/public/pages/Emails/CreateSender.tsx
+++ b/public/pages/Emails/CreateSender.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -128,9 +128,9 @@ export function CreateSender(props: CreateSenderProps) {
       <EuiSpacer />
       <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty href={`#${ROUTES.EMAIL_SENDERS}`}>
+          <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_SENDERS}`}>
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton

--- a/public/pages/Emails/__tests__/__snapshots__/CreateRecipientGroupForm.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateRecipientGroupForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<CreateRecipientGroupForm/> spec render errors 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 650px;"
 >
@@ -21,14 +21,14 @@ exports[`<CreateRecipientGroupForm/> spec render errors 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-help-0 random_html_id-error-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-recipient-group-form-name-input"
           id="random_html_id"
           placeholder="Enter recipient group name"
@@ -56,7 +56,7 @@ exports[`<CreateRecipientGroupForm/> spec render errors 1`] = `
 
 exports[`<CreateRecipientGroupForm/> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 650px;"
 >
@@ -75,14 +75,14 @@ exports[`<CreateRecipientGroupForm/> spec renders the component 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-help-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-recipient-group-form-name-input"
           id="random_html_id"
           placeholder="Enter recipient group name"

--- a/public/pages/Emails/__tests__/__snapshots__/CreateSESSenderForm.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateSESSenderForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<CreateSESSenderForm/> spec renders errors 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 650px;"
 >
@@ -21,14 +21,14 @@ exports[`<CreateSESSenderForm/> spec renders errors 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-help-0 random_html_id-error-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-ses-sender-form-name-input"
           id="random_html_id"
           placeholder="Enter sender name"
@@ -56,7 +56,7 @@ exports[`<CreateSESSenderForm/> spec renders errors 1`] = `
 
 exports[`<CreateSESSenderForm/> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 650px;"
 >
@@ -75,14 +75,14 @@ exports[`<CreateSESSenderForm/> spec renders the component 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-help-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-ses-sender-form-name-input"
           id="random_html_id"
           placeholder="Enter sender name"

--- a/public/pages/Emails/__tests__/__snapshots__/CreateSenderForm.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateSenderForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<CreateSenderForm/> spec renders errors 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 650px;"
 >
@@ -21,14 +21,14 @@ exports[`<CreateSenderForm/> spec renders errors 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-help-0 random_html_id-error-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-sender-form-name-input"
           id="random_html_id"
           placeholder="Enter sender name"
@@ -56,7 +56,7 @@ exports[`<CreateSenderForm/> spec renders errors 1`] = `
 
 exports[`<CreateSenderForm/> spec renders the component 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="random_html_id-row"
   style="max-width: 650px;"
 >
@@ -75,14 +75,14 @@ exports[`<CreateSenderForm/> spec renders the component 1`] = `
     class="euiFormRow__fieldWrapper"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
           aria-describedby="random_html_id-help-0"
-          class="euiFieldText euiFieldText--fullWidth"
+          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
           data-test-subj="create-sender-form-name-input"
           id="random_html_id"
           placeholder="Enter sender name"

--- a/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton-isDisabled"
+                class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                 data-test-subj="recipient-groups-table-delete-button"
                 disabled=""
                 type="button"
@@ -58,7 +58,7 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton-isDisabled"
+                class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                 data-test-subj="recipient-groups-table-edit-button"
                 disabled=""
                 type="button"
@@ -78,7 +78,7 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <a
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 href="#/create-recipient-group"
                 rel="noreferrer"
               >
@@ -105,13 +105,13 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
     style="padding: initial;"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
           data-test-subj="recipient-groups-table-search-input"
           placeholder="Search"
           type="search"
@@ -124,7 +124,7 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
               focusable="false"
               height="16"
               role="img"
@@ -389,7 +389,7 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
                         class="euiSpacer euiSpacer--l"
                       />
                       <a
-                        class="euiButton euiButton--primary"
+                        class="euiButton euiButton--primary euiButton--small"
                         href="#/create-recipient-group"
                         rel="noreferrer"
                       >

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton-isDisabled"
+                class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                 data-test-subj="senders-table-delete-button"
                 disabled=""
                 type="button"
@@ -58,7 +58,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton-isDisabled"
+                class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                 data-test-subj="senders-table-edit-button"
                 disabled=""
                 type="button"
@@ -78,7 +78,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <a
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 href="#/create-smtp-sender"
                 rel="noreferrer"
               >
@@ -111,13 +111,13 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
-              class="euiFieldSearch euiFieldSearch--fullWidth"
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
               data-test-subj="senders-table-search-input"
               placeholder="Search"
               type="search"
@@ -130,7 +130,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                   focusable="false"
                   height="16"
                   role="img"
@@ -160,7 +160,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
               class="euiPopover__anchor"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
                 type="button"
               >
                 <span
@@ -491,7 +491,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
                         class="euiSpacer euiSpacer--l"
                       />
                       <a
-                        class="euiButton euiButton--primary"
+                        class="euiButton euiButton--primary euiButton--small"
                         href="#/create-smtp-sender"
                         rel="noreferrer"
                       >

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
     class="euiFlexItem"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
           data-test-subj="senders-table-search-input"
           placeholder="Search"
           type="search"
@@ -27,7 +27,7 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
               focusable="false"
               height="16"
               role="img"
@@ -57,7 +57,7 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
             type="button"
           >
             <span

--- a/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
+++ b/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
@@ -7,7 +7,7 @@ import {
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFieldText,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
   EuiTextArea,
@@ -37,7 +37,7 @@ interface CreateRecipientGroupFormProps {
 export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
   return (
     <>
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Name"
         style={{ maxWidth: '650px' }}
         helpText="The name must contain 2 to 50 characters. Valid characters are A-Z, a-z, 0-9, (_) underscore, (-) hyphen and unicode characters."
@@ -58,10 +58,10 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
             });
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label={
           <span>
             Description - <i style={{ fontWeight: 'normal' }}>optional</i>
@@ -82,10 +82,10 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
             onChange={(e) => props.setDescription(e.target.value)}
           />
         </>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Emails"
         style={{ maxWidth: '650px' }}
         error={props.inputErrors.emailOptions.join(' ')}
@@ -130,7 +130,7 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
             }}
           />
         </>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
     </>

--- a/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
+++ b/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldText,
   EuiCompressedFormRow,
@@ -95,7 +95,7 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
           <EuiText size="xs" color="subdued">
             Select or type in one or more email addresses.
           </EuiText>
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder="Email addresses"
             data-test-subj="create-recipient-group-form-emails-input"
             fullWidth

--- a/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
+++ b/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
@@ -10,7 +10,7 @@ import {
   EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
-  EuiTextArea,
+  EuiCompressedTextArea,
 } from '@elastic/eui';
 import React from 'react';
 import { onComboBoxCreateOption } from '../../utils/helper';
@@ -73,7 +73,7 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
           <EuiText size="xs" color="subdued">
             Describe the purpose of the channel.
           </EuiText>
-          <EuiTextArea
+          <EuiCompressedTextArea
             fullWidth
             data-test-subj="create-recipient-group-form-description-input"
             placeholder="What is the purpose of this recipient group?"

--- a/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
+++ b/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
@@ -6,7 +6,7 @@
 import {
   EuiComboBox,
   EuiComboBoxOptionOption,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
@@ -44,7 +44,7 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
         error={props.inputErrors.name.join(' ')}
         isInvalid={props.inputErrors.name.length > 0}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           fullWidth
           data-test-subj="create-recipient-group-form-name-input"
           placeholder="Enter recipient group name"

--- a/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -43,7 +43,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
         error={props.inputErrors.senderName.join(' ')}
         isInvalid={props.inputErrors.senderName.length > 0}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           fullWidth
           placeholder="Enter sender name"
           data-test-subj="create-ses-sender-form-name-input"
@@ -66,7 +66,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
         error={props.inputErrors.email.join(' ')}
         isInvalid={props.inputErrors.email.length > 0}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           fullWidth
           placeholder="name@example.com"
           data-test-subj="create-ses-sender-form-email-input"
@@ -99,7 +99,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
             error={props.inputErrors.roleArn.join(' ')}
             isInvalid={props.inputErrors.roleArn.length > 0}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               placeholder="ARN key"
               data-test-subj="create-ses-sender-form-role-arn-input"
               value={props.roleArn}
@@ -122,7 +122,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
             error={props.inputErrors.awsRegion.join(' ')}
             isInvalid={props.inputErrors.awsRegion.length > 0}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               placeholder="us-east-1"
               data-test-subj="create-ses-sender-form-aws-region-input"
               value={props.awsRegion}

--- a/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
@@ -7,7 +7,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
 } from '@elastic/eui';
 import React, { useContext } from 'react';
@@ -36,7 +36,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
   const mainStateContext = useContext(MainContext)!;
   return (
     <>
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Sender name"
         style={{ maxWidth: '650px' }}
         helpText="Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, - (hyphen) and _ (underscore)."
@@ -57,10 +57,10 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
             });
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Email address"
         style={{ maxWidth: '650px' }}
         error={props.inputErrors.email.join(' ')}
@@ -80,12 +80,12 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
             });
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: '658px' }}>
         <EuiFlexItem grow={6}>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label={
               mainStateContext.tooltipSupport ? (
                 <span>
@@ -114,10 +114,10 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
                 }
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={4}>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="AWS region"
             error={props.inputErrors.awsRegion.join(' ')}
             isInvalid={props.inputErrors.awsRegion.length > 0}
@@ -135,7 +135,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
                 });
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/public/pages/Emails/components/forms/CreateSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSenderForm.tsx
@@ -11,7 +11,7 @@ import {
   EuiCompressedFormRow,
   EuiLink,
   EuiSpacer,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiSuperSelectOption,
 } from '@elastic/eui';
 import React from 'react';
@@ -160,7 +160,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
           </div>
         }
       >
-        <EuiSuperSelect
+        <EuiCompressedSuperSelect
           fullWidth
           data-test-subj="create-sender-form-encryption-input"
           options={encryptionOptions}

--- a/public/pages/Emails/components/forms/CreateSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSenderForm.tsx
@@ -8,7 +8,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiSpacer,
   EuiSuperSelect,
@@ -51,7 +51,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
 
   return (
     <>
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Sender name"
         style={{ maxWidth: '650px' }}
         helpText="Use a unique, descriptive name. The sender name must contain from 2 to 50 characters. Valid characters are lowercase a-z, 0-9, - (hyphen) and _ (underscore)."
@@ -72,12 +72,12 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
             });
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: '658px' }}>
         <EuiFlexItem grow={4}>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Email address"
             error={props.inputErrors.email.join(' ')}
             isInvalid={props.inputErrors.email.length > 0}
@@ -95,10 +95,10 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
                 });
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={4}>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Host"
             error={props.inputErrors.host.join(' ')}
             isInvalid={props.inputErrors.host.length > 0}
@@ -116,10 +116,10 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
                 });
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={2}>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Port"
             error={props.inputErrors.port.join(' ')}
             isInvalid={props.inputErrors.port.length > 0}
@@ -137,12 +137,12 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
                 });
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
 
       <EuiSpacer size="m" />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Encryption method"
         style={{ maxWidth: '650px' }}
         helpText={
@@ -167,7 +167,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
           valueOfSelected={props.encryption}
           onChange={props.setEncryption}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       <EuiSpacer size="m" />
     </>

--- a/public/pages/Emails/components/forms/CreateSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSenderForm.tsx
@@ -4,8 +4,8 @@
  */
 
 import {
-  EuiFieldNumber,
-  EuiFieldText,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -58,7 +58,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
         error={props.inputErrors.senderName.join(' ')}
         isInvalid={props.inputErrors.senderName.length > 0}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           fullWidth
           placeholder="Enter sender name"
           data-test-subj="create-sender-form-name-input"
@@ -82,7 +82,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
             error={props.inputErrors.email.join(' ')}
             isInvalid={props.inputErrors.email.length > 0}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               placeholder="name@example.com"
               data-test-subj="create-sender-form-email-input"
               value={props.email}
@@ -103,7 +103,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
             error={props.inputErrors.host.join(' ')}
             isInvalid={props.inputErrors.host.length > 0}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               placeholder="smtp.example.com"
               data-test-subj="create-sender-form-host-input"
               value={props.host}
@@ -124,7 +124,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
             error={props.inputErrors.port.join(' ')}
             isInvalid={props.inputErrors.port.length > 0}
           >
-            <EuiFieldNumber
+            <EuiCompressedFieldNumber
               placeholder="465"
               data-test-subj="create-sender-form-port-input"
               value={props.port}

--- a/public/pages/Emails/components/modals/DeleteRecipientGroupModal.tsx
+++ b/public/pages/Emails/components/modals/DeleteRecipientGroupModal.tsx
@@ -5,7 +5,7 @@
 
 import { SERVER_DELAY } from '../../../../../common';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiFlexGroup,
@@ -83,7 +83,7 @@ export const DeleteRecipientGroupModal = (
               <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 data-test-subj="delete-recipient-group-modal-delete-button"
                 fill
                 color="danger"
@@ -112,7 +112,7 @@ export const DeleteRecipientGroupModal = (
                 disabled={input !== 'delete'}
               >
                 Delete
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiModalFooter>

--- a/public/pages/Emails/components/modals/DeleteRecipientGroupModal.tsx
+++ b/public/pages/Emails/components/modals/DeleteRecipientGroupModal.tsx
@@ -6,7 +6,7 @@
 import { SERVER_DELAY } from '../../../../../common';
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -80,7 +80,7 @@ export const DeleteRecipientGroupModal = (
         <EuiModalFooter>
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
+              <EuiSmallButtonEmpty onClick={props.onClose}>Cancel</EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/pages/Emails/components/modals/DeleteRecipientGroupModal.tsx
+++ b/public/pages/Emails/components/modals/DeleteRecipientGroupModal.tsx
@@ -7,7 +7,7 @@ import { SERVER_DELAY } from '../../../../../common';
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiModal,
@@ -71,7 +71,7 @@ export const DeleteRecipientGroupModal = (
           <EuiText>
             To confirm delete, type <i>delete</i> in the field.
           </EuiText>
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="delete"
             value={input}
             onChange={(e) => setInput(e.target.value)}

--- a/public/pages/Emails/components/modals/DeleteSenderModal.tsx
+++ b/public/pages/Emails/components/modals/DeleteSenderModal.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -77,7 +77,7 @@ export const DeleteSenderModal = (props: DeleteSenderModalProps) => {
         <EuiModalFooter>
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
+              <EuiSmallButtonEmpty onClick={props.onClose}>Cancel</EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/pages/Emails/components/modals/DeleteSenderModal.tsx
+++ b/public/pages/Emails/components/modals/DeleteSenderModal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiFlexGroup,
@@ -80,7 +80,7 @@ export const DeleteSenderModal = (props: DeleteSenderModalProps) => {
               <EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 data-test-subj="delete-sender-modal-delete-button"
                 fill
                 color="danger"
@@ -110,7 +110,7 @@ export const DeleteSenderModal = (props: DeleteSenderModalProps) => {
                 disabled={input !== 'delete'}
               >
                 Delete
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiModalFooter>

--- a/public/pages/Emails/components/modals/DeleteSenderModal.tsx
+++ b/public/pages/Emails/components/modals/DeleteSenderModal.tsx
@@ -6,7 +6,7 @@
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiModal,
@@ -68,7 +68,7 @@ export const DeleteSenderModal = (props: DeleteSenderModalProps) => {
           <EuiText>
             To confirm delete, type <i>delete</i> in the field.
           </EuiText>
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="delete"
             value={input}
             onChange={(e) => setInput(e.target.value)}

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiEmptyPrompt,
   EuiFieldSearch,
   EuiHorizontalRule,
@@ -228,7 +228,7 @@ export class RecipientGroupsTable extends Component<
                   component: (
                     <ModalConsumer>
                       {({ onShow }) => (
-                        <EuiButton
+                        <EuiSmallButton
                           data-test-subj="recipient-groups-table-delete-button"
                           disabled={this.state.selectedItems.length === 0}
                           onClick={() =>
@@ -239,14 +239,14 @@ export class RecipientGroupsTable extends Component<
                           }
                         >
                           Delete
-                        </EuiButton>
+                        </EuiSmallButton>
                       )}
                     </ModalConsumer>
                   ),
                 },
                 {
                   component: (
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="recipient-groups-table-edit-button"
                       disabled={this.state.selectedItems.length !== 1}
                       onClick={() =>
@@ -256,14 +256,14 @@ export class RecipientGroupsTable extends Component<
                       }
                     >
                       Edit
-                    </EuiButton>
+                    </EuiSmallButton>
                   ),
                 },
                 {
                   component: (
-                    <EuiButton fill href={`#${ROUTES.CREATE_RECIPIENT_GROUP}`}>
+                    <EuiSmallButton fill href={`#${ROUTES.CREATE_RECIPIENT_GROUP}`}>
                       Create recipient group
-                    </EuiButton>
+                    </EuiSmallButton>
                   ),
                 },
               ]}
@@ -293,9 +293,9 @@ export class RecipientGroupsTable extends Component<
                 title={<h2>No recipient groups to display</h2>}
                 body="Use an email group to manage a list of email addresses you frequently send at a time. You can select recipient groups when configuring email channels."
                 actions={
-                  <EuiButton href={`#${ROUTES.CREATE_RECIPIENT_GROUP}`}>
+                  <EuiSmallButton href={`#${ROUTES.CREATE_RECIPIENT_GROUP}`}>
                     Create recipient group
-                  </EuiButton>
+                  </EuiSmallButton>
                 }
               />
             }

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -7,7 +7,7 @@ import {
   EuiBasicTable,
   EuiSmallButton,
   EuiEmptyPrompt,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiHorizontalRule,
   EuiLink,
   EuiTableFieldDataColumnType,
@@ -274,7 +274,7 @@ export class RecipientGroupsTable extends Component<
           titleSize="m"
           total={this.state.total}
         >
-          <EuiFieldSearch
+          <EuiCompressedFieldSearch
             data-test-subj="recipient-groups-table-search-input"
             fullWidth={true}
             placeholder="Search"

--- a/public/pages/Emails/components/tables/SESSendersTable.tsx
+++ b/public/pages/Emails/components/tables/SESSendersTable.tsx
@@ -7,7 +7,7 @@ import {
   EuiBasicTable,
   EuiSmallButton,
   EuiEmptyPrompt,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiHorizontalRule,
   EuiTableFieldDataColumnType,
   EuiTableSortingType,
@@ -237,7 +237,7 @@ export class SESSendersTable extends Component<
         titleSize="m"
         total={this.state.total}
       >
-        <EuiFieldSearch
+        <EuiCompressedFieldSearch
           data-test-subj="ses-senders-table-search-input"
           fullWidth={true}
           placeholder="Search"

--- a/public/pages/Emails/components/tables/SESSendersTable.tsx
+++ b/public/pages/Emails/components/tables/SESSendersTable.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiEmptyPrompt,
   EuiFieldSearch,
   EuiHorizontalRule,
@@ -191,7 +191,7 @@ export class SESSendersTable extends Component<
                 component: (
                   <ModalConsumer>
                     {({ onShow }) => (
-                      <EuiButton
+                      <EuiSmallButton
                         data-test-subj="ses-senders-table-delete-button"
                         disabled={this.state.selectedItems.length === 0}
                         onClick={() =>
@@ -202,14 +202,14 @@ export class SESSendersTable extends Component<
                         }
                       >
                         Delete
-                      </EuiButton>
+                      </EuiSmallButton>
                     )}
                   </ModalConsumer>
                 ),
               },
               {
                 component: (
-                  <EuiButton
+                  <EuiSmallButton
                     data-test-subj="ses-senders-table-edit-button"
                     disabled={this.state.selectedItems.length !== 1}
                     onClick={() =>
@@ -219,14 +219,14 @@ export class SESSendersTable extends Component<
                     }
                   >
                     Edit
-                  </EuiButton>
+                  </EuiSmallButton>
                 ),
               },
               {
                 component: (
-                  <EuiButton fill href={`#${ROUTES.CREATE_SES_SENDER}`}>
+                  <EuiSmallButton fill href={`#${ROUTES.CREATE_SES_SENDER}`}>
                     Create SES sender
-                  </EuiButton>
+                  </EuiSmallButton>
                 ),
               },
             ]}
@@ -256,9 +256,9 @@ export class SESSendersTable extends Component<
               title={<h2>No SES senders to display</h2>}
               body="Set up an outbound email server by creating a sender. You will select a sender when configuring email channels."
               actions={
-                <EuiButton href={`#${ROUTES.CREATE_SES_SENDER}`}>
+                <EuiSmallButton href={`#${ROUTES.CREATE_SES_SENDER}`}>
                   Create SES sender
-                </EuiButton>
+                </EuiSmallButton>
               }
             />
           }

--- a/public/pages/Emails/components/tables/SendersTable.tsx
+++ b/public/pages/Emails/components/tables/SendersTable.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiEmptyPrompt,
   EuiHorizontalRule,
   EuiTableFieldDataColumnType,
@@ -212,7 +212,7 @@ export class SendersTable extends Component<
                 component: (
                   <ModalConsumer>
                     {({ onShow }) => (
-                      <EuiButton
+                      <EuiSmallButton
                         data-test-subj="senders-table-delete-button"
                         disabled={this.state.selectedItems.length === 0}
                         onClick={() =>
@@ -223,14 +223,14 @@ export class SendersTable extends Component<
                         }
                       >
                         Delete
-                      </EuiButton>
+                      </EuiSmallButton>
                     )}
                   </ModalConsumer>
                 ),
               },
               {
                 component: (
-                  <EuiButton
+                  <EuiSmallButton
                     data-test-subj="senders-table-edit-button"
                     disabled={this.state.selectedItems.length !== 1}
                     onClick={() =>
@@ -240,14 +240,14 @@ export class SendersTable extends Component<
                     }
                   >
                     Edit
-                  </EuiButton>
+                  </EuiSmallButton>
                 ),
               },
               {
                 component: (
-                  <EuiButton fill href={`#${ROUTES.CREATE_SENDER}`}>
+                  <EuiSmallButton fill href={`#${ROUTES.CREATE_SENDER}`}>
                     Create SMTP sender
-                  </EuiButton>
+                  </EuiSmallButton>
                 ),
               },
             ]}
@@ -276,9 +276,9 @@ export class SendersTable extends Component<
               title={<h2>No SMTP senders to display</h2>}
               body="Set up an outbound email server by creating a sender. You will select a sender when configuring email channels."
               actions={
-                <EuiButton href={`#${ROUTES.CREATE_SENDER}`}>
+                <EuiSmallButton href={`#${ROUTES.CREATE_SENDER}`}>
                   Create SMTP sender
-                </EuiButton>
+                </EuiSmallButton>
               }
             />
           }

--- a/public/pages/Emails/components/tables/SendersTableControls.tsx
+++ b/public/pages/Emails/components/tables/SendersTableControls.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiCompressedFieldSearch,
-  EuiFilterButton,
+  EuiSmallFilterButton,
   EuiFilterGroup,
   EuiFilterSelectItem,
   EuiFlexGroup,
@@ -77,7 +77,7 @@ export const SendersTableControls = (props: SendersTableControlsProps) => {
         <EuiFilterGroup>
           <EuiPopover
             button={
-              <EuiFilterButton
+              <EuiSmallFilterButton
                 iconType="arrowDown"
                 grow={false}
                 onClick={() =>
@@ -89,7 +89,7 @@ export const SendersTableControls = (props: SendersTableControlsProps) => {
                 ) : (
                   'Encryption method'
                 )}
-              </EuiFilterButton>
+              </EuiSmallFilterButton>
             }
             isOpen={isEncryptionPopoverOpen}
             closePopover={() => setIsEncryptionPopoverOpen(false)}

--- a/public/pages/Emails/components/tables/SendersTableControls.tsx
+++ b/public/pages/Emails/components/tables/SendersTableControls.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiFilterButton,
   EuiFilterGroup,
   EuiFilterSelectItem,
@@ -65,7 +65,7 @@ export const SendersTableControls = (props: SendersTableControlsProps) => {
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
-        <EuiFieldSearch
+        <EuiCompressedFieldSearch
           data-test-subj="senders-table-search-input"
           fullWidth={true}
           placeholder="Search"

--- a/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
+++ b/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`<Main /> spec renders the component 1`] = `
                       class="euiPopover__anchor"
                     >
                       <button
-                        class="euiButton euiButton--primary euiButton-isDisabled"
+                        class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                         disabled=""
                         type="button"
                       >
@@ -184,7 +184,7 @@ exports[`<Main /> spec renders the component 1`] = `
                   class="euiFlexItem euiFlexItem--flexGrowZero"
                 >
                   <a
-                    class="euiButton euiButton--primary euiButton--fill"
+                    class="euiButton euiButton--primary euiButton--small euiButton--fill"
                     href="#/create-channel"
                     rel="noreferrer"
                   >
@@ -217,13 +217,13 @@ exports[`<Main /> spec renders the component 1`] = `
             class="euiFlexItem"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
-                  class="euiFieldSearch euiFieldSearch--fullWidth"
+                  class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
                   placeholder="Search"
                   type="search"
                 />
@@ -235,7 +235,7 @@ exports[`<Main /> spec renders the component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                       focusable="false"
                       height="16"
                       role="img"
@@ -265,7 +265,7 @@ exports[`<Main /> spec renders the component 1`] = `
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
                     type="button"
                   >
                     <span
@@ -307,7 +307,7 @@ exports[`<Main /> spec renders the component 1`] = `
                   class="euiPopover__anchor"
                 >
                   <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
                     type="button"
                   >
                     <span
@@ -616,7 +616,7 @@ exports[`<Main /> spec renders the component 1`] = `
                             class="euiSpacer euiSpacer--l"
                           />
                           <a
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             href="#/create-channel"
                             rel="noreferrer"
                           >


### PR DESCRIPTION
### Description
Replace instances of `EuiButton` that don't have an explicit sizing attribute to `EuiSmallButton*`.
Replace instances of `Eui<form elements>` that don't have density attributes to `EuiCompressed<form elements>`.

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
