### PR TITLE
Use TopNavControlButtonData for channel test button

### DIFF
--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -33,6 +33,7 @@ import { ChannelDetailItems } from './ChannelDetailItems';
 import { ChannelDetailsActions } from './ChannelDetailsActions';
 import { ChannelSettingsDetails } from './ChannelSettingsDetails';
 import PageHeader from "../../../../components/PageHeader/PageHeader";
+import { TopNavControlButtonData } from '../../../../../../../src/plugins/navigation/public';
 
 interface ChannelDetailsProps extends RouteComponentProps<{
   id: string
@@ -191,19 +192,12 @@ export function ChannelDetails(props: ChannelDetailsProps) {
       ),
     },
     {
-      renderComponent: (
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <EuiSmallButton
-            data-test-subj="send-test-message-button"
-            onClick={sendTestMessage}
-            style={{ marginLeft: '10px' }}
-            disabled={!channel?.is_enabled}
-          >
-            Send test message
-          </EuiSmallButton>
-        </div>
-      ),
-    },
+      controlType: 'button',
+      testId: 'send-test-message-button',
+      isDisabled: !channel?.is_enabled,
+      run: sendTestMessage,
+      label: 'Send test message',
+    } as TopNavControlButtonData,
   ];
 
   const badgeComponent = <EuiFlexItem grow={false} style={{ paddingBottom: 5 }}>


### PR DESCRIPTION
### Description
Use TopNavControlButtonData for channel test button

Note: All other buttons and the general styling of the page are created wrongly and with custom styling so nothing matches.

<img width="837" alt="Screenshot 2024-08-23 at 1 47 33 PM" src="https://github.com/user-attachments/assets/cbd9150a-ff6e-4f1f-b1dc-87e933b59962">



### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
