### PR TITLE
[Backport 2.x] Persist dataSourceId across applications under new Nav change (#244)

### DIFF
--- a/public/components/MDSEnabledComponent/MDSEnabledComponent.tsx
+++ b/public/components/MDSEnabledComponent/MDSEnabledComponent.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import { DataSourceMenuContext, DataSourceMenuProperties } from "../../services/DataSourceMenuContext";
 import _ from 'lodash'
+import { useHistory } from "react-router-dom";
+import queryString from "query-string";
 
 export default class MDSEnabledComponent<
   Props extends DataSourceMenuProperties,
@@ -29,6 +31,25 @@ export function isDataSourceChanged(prevProps, currentProps) {
   return false;
 }
 
-export function isDataSourceError(error) {
+export function isDataSourceError(error: { body: { message: string | string[]; }; }) {
   return (error.body && error.body.message && error.body.message.includes("Data Source Error"));
 }
+
+export function useUpdateUrlWithDataSourceProperties() {
+  const dataSourceMenuProps = useContext(DataSourceMenuContext);
+  const { dataSourceId, multiDataSourceEnabled } = dataSourceMenuProps;
+  const history = useHistory();
+  const currentSearch = history?.location?.search;
+  const currentQuery = queryString.parse(currentSearch);
+  useEffect(() => {
+    if (multiDataSourceEnabled) {
+      history.replace({
+        search: queryString.stringify({
+          ...currentQuery,
+          dataSourceId,
+        }),
+      });
+    }
+  }, [dataSourceId, multiDataSourceEnabled]);
+}
+

--- a/public/components/PageHeader/PageHeader.tsx
+++ b/public/components/PageHeader/PageHeader.tsx
@@ -10,6 +10,7 @@ import {
   TopNavControlLinkData,
 } from '../../../../../src/plugins/navigation/public';
 import { getApplication, getNavigationUI, getUseUpdatedUx } from '../../services/utils/constants';
+import { useUpdateUrlWithDataSourceProperties } from '../MDSEnabledComponent/MDSEnabledComponent';
 
 export interface PageHeaderProps {
   appRightControls?: TopNavControlData[];
@@ -27,6 +28,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({
 }) => {
   const { HeaderControl } = getNavigationUI();
   const { setAppBadgeControls, setAppRightControls, setAppDescriptionControls, setAppLeftControls } = getApplication();
+  useUpdateUrlWithDataSourceProperties();
 
   return getUseUpdatedUx() ? (
     <>

--- a/public/pages/Emails/EmailSenders.tsx
+++ b/public/pages/Emails/EmailSenders.tsx
@@ -13,6 +13,7 @@ import { SendersTable } from './components/tables/SendersTable';
 import { SESSendersTable } from './components/tables/SESSendersTable';
 import { NotificationService } from '../../services';
 import { getUseUpdatedUx } from '../../services/utils/constants';
+import { useUpdateUrlWithDataSourceProperties } from '../../components/MDSEnabledComponent/MDSEnabledComponent';
 
 interface EmailSendersProps extends RouteComponentProps {
   notificationService: NotificationService;
@@ -22,7 +23,9 @@ export function EmailSenders(props: EmailSendersProps) {
   const coreContext = useContext(CoreServicesContext)!;
   const mainStateContext = useContext(MainContext)!;
 
-
+  // Call the hook to manage URL updates
+  useUpdateUrlWithDataSourceProperties();
+  
   useEffect(() => {
     setBreadcrumbs([
       BREADCRUMBS.NOTIFICATIONS,

--- a/public/pages/Main/Main.tsx
+++ b/public/pages/Main/Main.tsx
@@ -11,7 +11,7 @@ import { CoreServicesConsumer, CoreServicesContext } from '../../components/core
 import { ModalProvider, ModalRoot } from '../../components/Modal';
 import { BrowserServices } from '../../models/interfaces';
 import { ServicesConsumer, ServicesContext } from '../../services/services';
-import { ROUTES } from '../../utils/constants';
+import { ROUTES, dataSourceObservable } from '../../utils/constants';
 import { CHANNEL_TYPE } from '../../../common/constants';
 import { Channels } from '../Channels/Channels';
 import { ChannelDetails } from '../Channels/components/details/ChannelDetails';
@@ -85,12 +85,20 @@ export default class Main extends Component<MainProps, MainState> {
         dataSourceLabel?: string;
       };
 
+      if (dataSourceId) {
+        dataSourceObservable.next({ id: dataSourceId, label: dataSourceLabel });
+      }
       this.state = {
         ...initialState,
         dataSourceId: dataSourceId,
         dataSourceLabel: dataSourceLabel,
         dataSourceReadOnly: false,
-        dataSourceLoading: props.multiDataSourceEnabled,
+         /**
+         * undefined: need data source picker to help to determine which data source to use.
+         * empty string: using the local cluster.
+         * string: using the selected data source.
+         */
+        dataSourceLoading: dataSourceId === undefined ? props.multiDataSourceEnabled : false,
       };
     } else {
       this.state = initialState;
@@ -124,7 +132,7 @@ export default class Main extends Component<MainProps, MainState> {
     ];
 
     let newState = {
-      dataSourceId: this.state.dataSourceId || '',
+      dataSourceId: this.state.dataSourceId,
       dataSourceLabel: this.state.dataSourceLabel || '',
       dataSourceReadOnly: false,
       dataSourceLoading: this.state.dataSourceLoading,
@@ -153,6 +161,7 @@ export default class Main extends Component<MainProps, MainState> {
         dataSourceId: id,
         dataSourceLabel: label,
       });
+      dataSourceObservable.next({ id, label });
     }
     if (this.state.dataSourceLoading) {
       this.setState({

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -5,6 +5,9 @@
 
 import { ChromeBreadcrumb } from 'opensearch-dashboards/public';
 import { getBreadCrumbsSetter, getUseUpdatedUx } from '../services/utils/constants';
+import { DataSourceOption } from 'src/plugins/data_source_management/public';
+import { i18n } from "@osd/i18n";
+import { BehaviorSubject } from 'rxjs';
 
 export const DOCUMENTATION_LINK = '';
 export const ALERTING_DOCUMENTATION_LINK =
@@ -72,3 +75,12 @@ export const CUSTOM_WEBHOOK_ENDPOINT_TYPE = Object.freeze({
 export function setBreadcrumbs(crumbs: ChromeBreadcrumb[]) {
   getBreadCrumbsSetter()(getUseUpdatedUx() ? crumbs : [BREADCRUMBS.NOTIFICATIONS, ...crumbs]);
 }
+
+const LocalCluster: DataSourceOption = {
+  label: i18n.translate("dataSource.localCluster", {
+    defaultMessage: "Local cluster",
+  }),
+  id: "",
+};
+
+export const dataSourceObservable = new BehaviorSubject<DataSourceOption>(LocalCluster);


### PR DESCRIPTION
Manual backport
* Persist dataSourceId across applications under new Nav change

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

* fixes with mds

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

* fixes with mds

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

* fix UTs

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

* moved to constants

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

* revert changes in snapshot files

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

---------

Signed-off-by: Riya Saxena <riysaxen@amazon.com>
Co-authored-by: Amardeepsingh Siglani <amardeep7194@gmail.com>
(cherry picked from commit f209c40d3124fb5a52fde7b081684aec4f7fc76f)

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
