### PR TITLE
Fit and Finish UX Fixes

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml
@@ -120,7 +120,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: dashboards-notifications
           path: OpenSearch-Dashboards/plugins/dashboards-notifications/build

--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -196,14 +196,14 @@ jobs:
           CYPRESS_CACHE_FOLDER: ${{ matrix.cypress_cache_folder }}
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots-${{ matrix.os }}
           path: OpenSearch-Dashboards/plugins/dashboards-notifications/.cypress/screenshots
 
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos-${{ matrix.os }}
@@ -218,7 +218,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: dashboards-notifications
           path: OpenSearch-Dashboards/plugins/dashboards-notifications/build

--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -8,7 +8,7 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiPanel,
-  EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import React from 'react';
 
@@ -40,7 +40,7 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
       alignItems="center"
     >
       <EuiFlexItem>
-        <EuiText size={titleSize}>
+        <EuiTitle size={titleSize}>
           <h2>
             {title}
             {total !== undefined ? (
@@ -49,7 +49,7 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
               >{` (${total})`}</span>
             ) : null}
           </h2>
-        </EuiText>
+        </EuiTitle>
       </EuiFlexItem>
       {actions ? (
         <EuiFlexItem grow={false}>

--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -70,7 +70,7 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
 
     <EuiHorizontalRule margin="s" className={horizontalRuleClassName} />
 
-    <div style={{ padding: '0px 10px', ...bodyStyles }}>{children}</div>
+    <div style={{ padding: '0px', ...bodyStyles }}>{children}</div>
   </EuiPanel>
 );
 

--- a/public/components/__tests__/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/__tests__/__snapshots__/ContentPanel.test.tsx.snap
@@ -11,13 +11,11 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h2
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          Testing
-        </h2>
-      </div>
+        Testing
+      </h2>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -39,7 +37,7 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
     class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
   />
   <div
-    style="padding: 0px 10px;"
+    style="padding: 0px;"
   >
     <div>
       Testing ContentPanel
@@ -59,20 +57,18 @@ exports[`<ContentPanel /> spec renders with empty actions 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h2
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          Testing
-        </h2>
-      </div>
+        Testing
+      </h2>
     </div>
   </div>
   <hr
     class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
   />
   <div
-    style="padding: 0px 10px;"
+    style="padding: 0px;"
   >
     <div>
       Testing ContentPanel

--- a/public/pages/Channels/Channels.tsx
+++ b/public/pages/Channels/Channels.tsx
@@ -281,7 +281,7 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
             <div style={{ marginBottom: '10px' }}>
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 {channelControlsComponent}
-                <div style={{ marginLeft: '10px' }}>
+                <div style={{ marginLeft: '16px' }}>
                   {channelActionsComponent}
                 </div>
               </div>

--- a/public/pages/Channels/Channels.tsx
+++ b/public/pages/Channels/Channels.tsx
@@ -277,7 +277,7 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
             appRightControls={headerControls}
             appLeftControls={[{ renderComponent: totalChannels }]}
           />
-          <ContentPanel>
+          <ContentPanel panelStyles={{ padding: this.state.total < 1? '16px 16px 0px' : '16px' }}>
             <div style={{ marginBottom: '10px' }}>
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 {channelControlsComponent}

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ChannelControls /> spec renders the component 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
 >
   <div
     class="euiFlexItem"

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelDetails.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelDetails.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
 <div>
   <div
     class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-    style="max-width: 1316px;"
+    style="padding: 0px 8px 0px 0px;"
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <div
-        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
       >
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -25,12 +25,12 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
-          style="padding-bottom: 5px;"
+          style="padding-top: 5px;"
         />
       </div>
     </div>
     <div
-      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem"
@@ -48,7 +48,6 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
   />
   <div
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    style="max-width: 1300px;"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -57,13 +56,11 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <div
-          class="euiText euiText--small"
+        <h2
+          class="euiTitle euiTitle--small"
         >
-          <h2>
-            Name and description
-          </h2>
-        </div>
+          Name and description
+        </h2>
       </div>
     </div>
     <hr
@@ -148,7 +145,6 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
   />
   <div
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    style="max-width: 1300px;"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -157,13 +153,11 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <div
-          class="euiText euiText--small"
+        <h2
+          class="euiTitle euiTitle--small"
         >
-          <h2>
-            Configurations
-          </h2>
-        </div>
+          Configurations
+        </h2>
       </div>
     </div>
     <hr
@@ -180,13 +174,13 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
 <div>
   <div
     class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-    style="max-width: 1316px;"
+    style="padding: 0px 8px 0px 0px;"
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <div
-        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
       >
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -201,12 +195,12 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
-          style="padding-bottom: 5px;"
+          style="padding-top: 5px;"
         />
       </div>
     </div>
     <div
-      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem"
@@ -224,7 +218,6 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
   />
   <div
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    style="max-width: 1300px;"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -233,13 +226,11 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <div
-          class="euiText euiText--small"
+        <h2
+          class="euiTitle euiTitle--small"
         >
-          <h2>
-            Name and description
-          </h2>
-        </div>
+          Name and description
+        </h2>
       </div>
     </div>
     <hr
@@ -324,7 +315,6 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
   />
   <div
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    style="max-width: 1300px;"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -333,13 +323,11 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <div
-          class="euiText euiText--small"
+        <h2
+          class="euiTitle euiTitle--small"
         >
-          <h2>
-            Configurations
-          </h2>
-        </div>
+          Configurations
+        </h2>
       </div>
     </div>
     <hr
@@ -355,13 +343,13 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
 exports[`<ChannelDetails/> spec renders the component 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-  style="max-width: 1316px;"
+  style="padding: 0px 8px 0px 0px;"
 >
   <div
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -376,12 +364,12 @@ exports[`<ChannelDetails/> spec renders the component 1`] = `
       </div>
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"
-        style="padding-bottom: 5px;"
+        style="padding-top: 5px;"
       />
     </div>
   </div>
   <div
-    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
   >
     <div
       class="euiFlexItem"

--- a/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -11,18 +11,16 @@ exports[`<Channels/> spec renders the empty component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h2
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          Channels
-          <span
-            style="color: rgb(159, 159, 159); font-weight: 300;"
-          >
-             (0)
-          </span>
-        </h2>
-      </div>
+        Channels
+        <span
+          style="color: rgb(159, 159, 159); font-weight: 300;"
+        >
+           (0)
+        </span>
+      </h2>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -108,7 +106,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
     style="padding: initial;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem"

--- a/public/pages/Channels/components/ChannelControls.tsx
+++ b/public/pages/Channels/components/ChannelControls.tsx
@@ -96,7 +96,7 @@ export const ChannelControls = (props: ChannelControlsProps) => {
   }
 
   return (
-    <EuiFlexGroup>
+    <EuiFlexGroup gutterSize={'m'}>
       <EuiFlexItem>
         <EuiCompressedFieldSearch
           fullWidth={true}

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -143,8 +143,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
     },
   ];
 
-  const actionsAndMuteComponent = <EuiFlexGroup gutterSize="m" alignItems="flexEnd">
-    <EuiFlexItem />
+  const actionsAndMuteComponent = <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
     <EuiFlexItem grow={false}>
       {channel && (
         <ChannelDetailsActions

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -143,7 +143,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
     },
   ];
 
-  const actionsAndMuteComponent = <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
+  const actionsAndMuteComponent = <EuiFlexGroup gutterSize="s" alignItems="center">
     <EuiFlexItem grow={false}>
       {channel && (
         <ChannelDetailsActions
@@ -225,10 +225,9 @@ export function ChannelDetails(props: ChannelDetailsProps) {
           <EuiFlexGroup
           alignItems="center"
           gutterSize="m"
-          style={{ maxWidth: 1316 }}
         >
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="m" alignItems="flexEnd">
+            <EuiFlexGroup gutterSize="m" alignItems="center">
               <EuiFlexItem grow={false}>
                 <EuiText size="s">
                   <h1>{channel?.name ?? '-'}</h1>

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -33,6 +33,7 @@ import { ChannelDetailsActions } from './ChannelDetailsActions';
 import { ChannelSettingsDetails } from './ChannelSettingsDetails';
 import PageHeader from "../../../../components/PageHeader/PageHeader";
 import { TopNavControlButtonData } from '../../../../../../../src/plugins/navigation/public';
+import { getUseUpdatedUx } from '../../../../services/utils/constants';
 
 interface ChannelDetailsProps extends RouteComponentProps<{
   id: string
@@ -242,6 +243,8 @@ export function ChannelDetails(props: ChannelDetailsProps) {
           </EuiFlexGroup>
         )}
       </PageHeader>
+
+      {!getUseUpdatedUx() && <EuiSpacer />}
 
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -242,7 +242,6 @@ export function ChannelDetails(props: ChannelDetailsProps) {
         )}
       </PageHeader>
 
-      <EuiSpacer />
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}
         title="Name and description"

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -196,6 +196,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
       isDisabled: !channel?.is_enabled,
       run: sendTestMessage,
       label: 'Send test message',
+      fill: true,
     } as TopNavControlButtonData,
   ];
 
@@ -247,7 +248,6 @@ export function ChannelDetails(props: ChannelDetailsProps) {
         bodyStyles={{ padding: 'initial' }}
         title="Name and description"
         titleSize="s"
-        panelStyles={{ maxWidth: 1300 }}
       >
         <ChannelDetailItems listItems={nameList} />
       </ContentPanel>
@@ -258,7 +258,6 @@ export function ChannelDetails(props: ChannelDetailsProps) {
         bodyStyles={{ padding: 'initial' }}
         title="Configurations"
         titleSize="s"
-        panelStyles={{ maxWidth: 1300 }}
       >
         <ChannelSettingsDetails channel={channel} />
       </ContentPanel>

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -144,6 +144,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
   ];
 
   const actionsAndMuteComponent = <EuiFlexGroup gutterSize="s" alignItems="center">
+    <EuiFlexItem />
     <EuiFlexItem grow={false}>
       {channel && (
         <ChannelDetailsActions
@@ -225,6 +226,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
           <EuiFlexGroup
           alignItems="center"
           gutterSize="m"
+          style={{ padding: '0px 8px 0px 0px' }}
         >
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="m" alignItems="center">

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -199,7 +199,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
     } as TopNavControlButtonData,
   ];
 
-  const badgeComponent = <EuiFlexItem grow={false} style={{ paddingBottom: 5 }}>
+  const badgeComponent = <EuiFlexItem grow={false} style={{ paddingTop: '5px' }}>
     {channel?.is_enabled === undefined ? null : channel.is_enabled ? (
       <EuiHealth color="success">Active</EuiHealth>
     ) : (

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -373,10 +373,13 @@ export function CreateChannel(props: CreateChannelsProps) {
       <CreateChannelContext.Provider
         value={{ edit: props.edit, inputErrors, setInputErrors }}
       >
-       {!getUseUpdatedUx() && (
-          <EuiText size="s">
-            <h1>{`${props.edit ? 'Edit' : 'Create'} channel`}</h1>
-          </EuiText>
+        {!getUseUpdatedUx() && (
+          <>
+            <EuiText size="s">
+              <h1>{`${props.edit ? 'Edit' : 'Create'} channel`}</h1>
+            </EuiText>
+            <EuiSpacer />
+          </>
         )}
 
         <ChannelNamePanel

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -379,7 +379,6 @@ export function CreateChannel(props: CreateChannelsProps) {
           </EuiText>
         )}
 
-        <EuiSpacer />
         <ChannelNamePanel
           name={name}
           setName={setName}

--- a/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
@@ -11,13 +11,11 @@ exports[`<ChannelNamePanel/> spec renders errors 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h2
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          Name and description
-        </h2>
-      </div>
+        Name and description
+      </h2>
     </div>
   </div>
   <hr
@@ -120,13 +118,11 @@ exports[`<ChannelNamePanel/> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h2
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          Name and description
-        </h2>
-      </div>
+        Name and description
+      </h2>
     </div>
   </div>
   <hr

--- a/public/pages/Emails/CreateRecipientGroup.tsx
+++ b/public/pages/Emails/CreateRecipientGroup.tsx
@@ -111,9 +111,12 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
-          <h1>{`${props.edit ? 'Edit' : 'Create'} recipient group`}</h1>
-        </EuiText>
+        <>
+          <EuiText size="s">
+            <h1>{`${props.edit ? 'Edit' : 'Create'} recipient group`}</h1>
+          </EuiText>
+          <EuiSpacer />
+        </>
       )}
 
       <ContentPanel

--- a/public/pages/Emails/CreateRecipientGroup.tsx
+++ b/public/pages/Emails/CreateRecipientGroup.tsx
@@ -116,7 +116,6 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
         </EuiText>
       )}
 
-      <EuiSpacer />
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}
         title="Configure recipient group"

--- a/public/pages/Emails/CreateRecipientGroup.tsx
+++ b/public/pages/Emails/CreateRecipientGroup.tsx
@@ -121,7 +121,6 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
         bodyStyles={{ padding: 'initial' }}
         title="Configure recipient group"
         titleSize="s"
-        panelStyles={{ maxWidth: 1000 }}
       >
         <CreateRecipientGroupForm
           name={name}
@@ -137,7 +136,7 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
         />
       </ContentPanel>
       <EuiSpacer />
-      <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
+      <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
           <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_GROUPS}`}>
             Cancel

--- a/public/pages/Emails/CreateSESSender.tsx
+++ b/public/pages/Emails/CreateSESSender.tsx
@@ -107,7 +107,6 @@ export function CreateSESSender(props: CreateSESSenderProps) {
         </EuiText>
       )}
 
-      <EuiSpacer />
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}
         title="Configure sender"

--- a/public/pages/Emails/CreateSESSender.tsx
+++ b/public/pages/Emails/CreateSESSender.tsx
@@ -102,9 +102,12 @@ export function CreateSESSender(props: CreateSESSenderProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
-          <h1>{`${props.edit ? 'Edit' : 'Create'} SES sender`}</h1>
-        </EuiText>
+        <>
+          <EuiText size="s">
+            <h1>{`${props.edit ? 'Edit' : 'Create'} SES sender`}</h1>
+          </EuiText>
+          <EuiSpacer />
+        </>
       )}
 
       <ContentPanel

--- a/public/pages/Emails/CreateSESSender.tsx
+++ b/public/pages/Emails/CreateSESSender.tsx
@@ -112,7 +112,6 @@ export function CreateSESSender(props: CreateSESSenderProps) {
         bodyStyles={{ padding: 'initial' }}
         title="Configure sender"
         titleSize="s"
-        panelStyles={{ maxWidth: 1000 }}
       >
         <CreateSESSenderForm
           senderName={senderName}
@@ -129,7 +128,7 @@ export function CreateSESSender(props: CreateSESSenderProps) {
       </ContentPanel>
 
       <EuiSpacer />
-      <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
+      <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
           <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_SENDERS}`}>
             Cancel

--- a/public/pages/Emails/CreateSender.tsx
+++ b/public/pages/Emails/CreateSender.tsx
@@ -99,9 +99,12 @@ export function CreateSender(props: CreateSenderProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
-          <h1>{`${props.edit ? 'Edit' : 'Create'} SMTP sender`}</h1>
-        </EuiText>
+        <>
+          <EuiText size="s">
+            <h1>{`${props.edit ? 'Edit' : 'Create'} SMTP sender`}</h1>
+          </EuiText>
+          <EuiSpacer />
+        </>
       )}
 
       <ContentPanel

--- a/public/pages/Emails/CreateSender.tsx
+++ b/public/pages/Emails/CreateSender.tsx
@@ -109,7 +109,6 @@ export function CreateSender(props: CreateSenderProps) {
         bodyStyles={{ padding: 'initial' }}
         title="Configure sender"
         titleSize="s"
-        panelStyles={{ maxWidth: 1000 }}
       >
         <CreateSenderForm
           senderName={senderName}
@@ -128,7 +127,7 @@ export function CreateSender(props: CreateSenderProps) {
       </ContentPanel>
 
       <EuiSpacer />
-      <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
+      <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
           <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_SENDERS}`}>
             Cancel

--- a/public/pages/Emails/CreateSender.tsx
+++ b/public/pages/Emails/CreateSender.tsx
@@ -104,7 +104,6 @@ export function CreateSender(props: CreateSenderProps) {
         </EuiText>
       )}
 
-      <EuiSpacer />
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}
         title="Configure sender"

--- a/public/pages/Emails/EmailGroups.tsx
+++ b/public/pages/Emails/EmailGroups.tsx
@@ -29,9 +29,12 @@ export function EmailGroups(props: EmailGroupsProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
-          <h1>Email recipient groups</h1>
-        </EuiText>
+        <>
+          <EuiText size="s">
+            <h1>Email recipient groups</h1>
+          </EuiText>
+          <EuiSpacer />
+        </>
       )}
 
       <RecipientGroupsTable coreContext={coreContext}

--- a/public/pages/Emails/EmailGroups.tsx
+++ b/public/pages/Emails/EmailGroups.tsx
@@ -34,7 +34,6 @@ export function EmailGroups(props: EmailGroupsProps) {
         </EuiText>
       )}
 
-      <EuiSpacer />
       <RecipientGroupsTable coreContext={coreContext}
         notificationService={props.notificationService}
       />

--- a/public/pages/Emails/EmailSenders.tsx
+++ b/public/pages/Emails/EmailSenders.tsx
@@ -43,7 +43,6 @@ export function EmailSenders(props: EmailSendersProps) {
       )}
       {mainStateContext.availableConfigTypes.includes('smtp_account') && (
         <>
-          <EuiSpacer />
           <SendersTable coreContext={coreContext}
             notificationService={props.notificationService}
           />

--- a/public/pages/Emails/EmailSenders.tsx
+++ b/public/pages/Emails/EmailSenders.tsx
@@ -37,9 +37,12 @@ export function EmailSenders(props: EmailSendersProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
-          <h1>Email senders</h1>
-        </EuiText>
+        <>
+          <EuiText size="s">
+            <h1>Email senders</h1>
+          </EuiText>
+          <EuiSpacer />
+        </>
       )}
       {mainStateContext.availableConfigTypes.includes('smtp_account') && (
         <>

--- a/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
@@ -11,18 +11,16 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h2
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          Recipient groups
-          <span
-            style="color: rgb(159, 159, 159); font-weight: 300;"
-          >
-             (0)
-          </span>
-        </h2>
-      </div>
+        Recipient groups
+        <span
+          style="color: rgb(159, 159, 159); font-weight: 300;"
+        >
+           (0)
+        </span>
+      </h2>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
@@ -11,18 +11,16 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h2
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          SMTP senders
-          <span
-            style="color: rgb(159, 159, 159); font-weight: 300;"
-          >
-             (0)
-          </span>
-        </h2>
-      </div>
+        SMTP senders
+        <span
+          style="color: rgb(159, 159, 159); font-weight: 300;"
+        >
+           (0)
+        </span>
+      </h2>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -107,7 +105,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
     style="padding: initial;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem"

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SendersTableControls /> spec renders the component 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
 >
   <div
     class="euiFlexItem"

--- a/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
+++ b/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
@@ -60,7 +60,7 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
         />
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       <EuiCompressedFormRow
         label={
           <span>
@@ -84,7 +84,7 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
         </>
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       <EuiCompressedFormRow
         label="Emails"
         style={{ maxWidth: '650px' }}

--- a/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
@@ -59,7 +59,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
         />
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       <EuiCompressedFormRow
         label="Email address"
         style={{ maxWidth: '650px' }}
@@ -82,7 +82,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
         />
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: '658px' }}>
         <EuiFlexItem grow={6}>
           <EuiCompressedFormRow

--- a/public/pages/Emails/components/forms/CreateSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSenderForm.tsx
@@ -74,7 +74,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
         />
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: '658px' }}>
         <EuiFlexItem grow={4}>
           <EuiCompressedFormRow
@@ -141,7 +141,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
         </EuiFlexItem>
       </EuiFlexGroup>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       <EuiCompressedFormRow
         label="Encryption method"
         style={{ maxWidth: '650px' }}

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -309,7 +309,7 @@ export class RecipientGroupsTable extends Component<
               appLeftControls={[{ renderComponent: totalEmailGroups }]}
             />
             <ContentPanel>
-              <EuiFlexGroup>
+              <EuiFlexGroup gutterSize={'m'}>
                 <EuiFlexItem>
                   {searchComponent}
                 </EuiFlexItem>
@@ -321,7 +321,6 @@ export class RecipientGroupsTable extends Component<
                         iconType="arrowDown"
                         iconSide="right"
                         onClick={this.togglePopover}
-                        style={{ marginLeft: '10px' }} // Ensure spacing is correct
                       >
                         Actions
                       </EuiSmallButton>

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -308,7 +308,11 @@ export class RecipientGroupsTable extends Component<
               appRightControls={headerControls}
               appLeftControls={[{ renderComponent: totalEmailGroups }]}
             />
-            <ContentPanel>
+            <ContentPanel
+              panelStyles={{
+                padding: this.state.total < 1 ? '16px 16px 0px' : '16px',
+              }}
+            >
               <EuiFlexGroup gutterSize={'m'}>
                 <EuiFlexItem>
                   {searchComponent}

--- a/public/pages/Emails/components/tables/SESSendersTable.tsx
+++ b/public/pages/Emails/components/tables/SESSendersTable.tsx
@@ -263,7 +263,7 @@ export class SESSendersTable extends Component<
             titleSize="s"
             total={this.state.total}
           >
-            <EuiFlexGroup>
+            <EuiFlexGroup gutterSize={'m'}>
               <EuiFlexItem>
                 {searchComponent}
               </EuiFlexItem>
@@ -275,7 +275,6 @@ export class SESSendersTable extends Component<
                       iconType="arrowDown"
                       iconSide="right"
                       onClick={this.togglePopover}
-                      style={{ marginLeft: '10px' }} // Ensure spacing is correct
                     >
                       Actions
                     </EuiSmallButton>

--- a/public/pages/Emails/components/tables/SESSendersTable.tsx
+++ b/public/pages/Emails/components/tables/SESSendersTable.tsx
@@ -245,6 +245,9 @@ export class SESSendersTable extends Component<
       <>
         {getUseUpdatedUx() ? (
           <ContentPanel
+            panelStyles={{
+              padding: this.state.total < 1 ? '16px 16px 0px' : '16px',
+            }}
             actions={
               <ContentPanelActions
                 actions={[

--- a/public/pages/Emails/components/tables/SendersTable.tsx
+++ b/public/pages/Emails/components/tables/SendersTable.tsx
@@ -287,7 +287,7 @@ export class SendersTable extends Component<
             titleSize="s"
             total={this.state.total}
           >
-            <EuiFlexGroup>
+            <EuiFlexGroup gutterSize={'m'}>
               <EuiFlexItem>
                 {senderControlComponent}
               </EuiFlexItem>
@@ -299,7 +299,6 @@ export class SendersTable extends Component<
                       iconType="arrowDown"
                       iconSide="right"
                       onClick={this.togglePopover}
-                      style={{ marginLeft: '10px' }} // Ensure spacing is correct
                     >
                       Actions
                     </EuiSmallButton>

--- a/public/pages/Emails/components/tables/SendersTable.tsx
+++ b/public/pages/Emails/components/tables/SendersTable.tsx
@@ -269,6 +269,9 @@ export class SendersTable extends Component<
       <>
         {getUseUpdatedUx() ? (
           <ContentPanel
+            panelStyles={{
+              padding: this.state.total < 1 ? '16px 16px 0px' : '16px',
+            }}
             actions={
               <ContentPanelActions
                 actions={[

--- a/public/pages/Emails/components/tables/SendersTableControls.tsx
+++ b/public/pages/Emails/components/tables/SendersTableControls.tsx
@@ -63,7 +63,7 @@ export const SendersTableControls = (props: SendersTableControlsProps) => {
   }
 
   return (
-    <EuiFlexGroup>
+    <EuiFlexGroup gutterSize={'m'}>
       <EuiFlexItem>
         <EuiCompressedFieldSearch
           data-test-subj="senders-table-search-input"

--- a/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
+++ b/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
@@ -116,18 +116,16 @@ exports[`<Main /> spec renders the component 1`] = `
         <div
           class="euiFlexItem"
         >
-          <div
-            class="euiText euiText--small"
+          <h2
+            class="euiTitle euiTitle--small"
           >
-            <h2>
-              Channels
-              <span
-                style="color: rgb(159, 159, 159); font-weight: 300;"
-              >
-                 (0)
-              </span>
-            </h2>
-          </div>
+            Channels
+            <span
+              style="color: rgb(159, 159, 159); font-weight: 300;"
+            >
+               (0)
+            </span>
+          </h2>
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -213,7 +211,7 @@ exports[`<Main /> spec renders the component 1`] = `
         style="padding: initial;"
       >
         <div
-          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+          class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
           <div
             class="euiFlexItem"


### PR DESCRIPTION
### Description
Addresses the fit and finish UX changes. Changes in this PR include:
- Fills the send test message button in the View Channel page
- Fixes the spacing across the data source to actions buttons in the View Channel page
- Makes all content sections run full width of page
- Removes extra 10px padding in Channels and Email recipient groups page
- Removes bottom border across pages when empty prompt
- Fixes the content to header spacing (16px)
- Fixes active indicator alignment in the View Channel page
- Fixes the section headers so it's wrapped in OuiTitle with size = s
- Fixes spacing for actions across elements from search bar (8px)

Empty Channels Page
![Screenshot 2024-09-16 at 8 40 17 PM](https://github.com/user-attachments/assets/91caeb7e-a1d6-44fc-97c6-1f6f80631a06)

Channels Page
![Screenshot 2024-09-16 at 8 40 58 PM](https://github.com/user-attachments/assets/fc24cbd6-5095-488a-a82c-52ed112ae12d)

Edit Channel Page
![Screenshot 2024-09-16 at 8 42 59 PM](https://github.com/user-attachments/assets/0f82a93f-9888-498f-b59c-5f09b05a84da)

Email Senders Page
![Screenshot 2024-09-16 at 8 41 11 PM](https://github.com/user-attachments/assets/16d60b81-2890-46aa-a184-9f513b07eba4)

Create SMTP Sender Page
![Screenshot 2024-09-16 at 8 41 25 PM](https://github.com/user-attachments/assets/384dcea5-b327-4930-b40e-bea9e0e79fe1)

Create SES Sender Page
![Screenshot 2024-09-16 at 8 41 54 PM](https://github.com/user-attachments/assets/4507736d-9dd2-4d46-9458-6d2d3f63c31e)

Email Recipient Group Page
![Screenshot 2024-09-16 at 8 42 08 PM](https://github.com/user-attachments/assets/363a7bd3-b658-4bb5-bc80-8807672844c8)

Edit Recipient Group Page
![Screenshot 2024-09-16 at 8 42 37 PM](https://github.com/user-attachments/assets/02f68bcb-de9a-48a1-a0c5-925e0335543a)

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
