### PR TITLE
Fit and Finish UX Fixes Pt 2.

### DIFF
--- a/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
@@ -91,6 +91,14 @@ exports[`<ChannelControls /> spec renders the component 1`] = `
           </button>
         </div>
       </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      class="euiFilterGroup"
+    >
       <div
         class="euiPopover euiPopover--anchorDownCenter"
       >

--- a/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -195,6 +195,14 @@ exports[`<Channels/> spec renders the empty component 1`] = `
               </button>
             </div>
           </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <div
+          class="euiFilterGroup"
+        >
           <div
             class="euiPopover euiPopover--anchorDownCenter"
           >

--- a/public/pages/Channels/components/ChannelControls.tsx
+++ b/public/pages/Channels/components/ChannelControls.tsx
@@ -136,6 +136,10 @@ export const ChannelControls = (props: ChannelControlsProps) => {
               );
             })}
           </EuiPopover>
+        </EuiFilterGroup>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiFilterGroup>
           <EuiPopover
             button={
               <EuiSmallFilterButton

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
               class="euiPopover__anchor"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon euiFilterButton--noGrow"
                 type="button"
               >
                 <span
@@ -181,7 +181,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
                     />
                   </svg>
                   <span
-                    class="euiButtonEmpty__text"
+                    class="euiButtonEmpty__text euiFilterButton__text-hasNotification"
                   >
                     <span
                       class="euiFilterButton__textShift"
@@ -189,6 +189,12 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
                       title="Encryption method"
                     >
                       Encryption method
+                    </span>
+                    <span
+                      aria-label="0 available filters"
+                      class="euiNotificationBadge euiNotificationBadge--medium euiNotificationBadge--subdued euiFilterButton__notification"
+                    >
+                      0
                     </span>
                   </span>
                 </span>

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon euiFilterButton--noGrow"
             type="button"
           >
             <span
@@ -78,7 +78,7 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
                 />
               </svg>
               <span
-                class="euiButtonEmpty__text"
+                class="euiButtonEmpty__text euiFilterButton__text-hasNotification"
               >
                 <span
                   class="euiFilterButton__textShift"
@@ -86,6 +86,12 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
                   title="Encryption method"
                 >
                   Encryption method
+                </span>
+                <span
+                  aria-label="0 available filters"
+                  class="euiNotificationBadge euiNotificationBadge--medium euiNotificationBadge--subdued euiFilterButton__notification"
+                >
+                  0
                 </span>
               </span>
             </span>

--- a/public/pages/Emails/components/tables/SendersTableControls.tsx
+++ b/public/pages/Emails/components/tables/SendersTableControls.tsx
@@ -78,6 +78,9 @@ export const SendersTableControls = (props: SendersTableControlsProps) => {
           <EuiPopover
             button={
               <EuiSmallFilterButton
+                numFilters={
+                  encryptionItems.filter((item) => item.checked === 'on').length
+                }
                 iconType="arrowDown"
                 grow={false}
                 onClick={() =>

--- a/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
+++ b/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
@@ -300,6 +300,14 @@ exports[`<Main /> spec renders the component 1`] = `
                   </button>
                 </div>
               </div>
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiFilterGroup"
+            >
               <div
                 class="euiPopover euiPopover--anchorDownCenter"
               >


### PR DESCRIPTION
### Description
Last changes for the fit and finish UX fixes. The changes in this PR include:
- Separating the table filters
- Adding a default pill to the encryption method dropdown

![Screenshot 2024-09-18 at 1 14 38 PM](https://github.com/user-attachments/assets/eac30b87-8b06-4caf-b053-fe6eab4e9d45)

![Screenshot 2024-09-18 at 1 14 25 PM](https://github.com/user-attachments/assets/c4713297-2956-4100-ad1d-203254998482)

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
