### PR TITLE
Fix CI workflow for windows

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -220,5 +220,5 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dashboards-notifications
+          name: dashboards-notifications-${{ matrix.os }}
           path: OpenSearch-Dashboards/plugins/dashboards-notifications/build


### PR DESCRIPTION
### Description
upload-artifact v4 doesn't allow uploading the same artifact name from multiple jobs. This PR updates the name of artifact that is uploaded so it's os specific.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
