### PR TITLE
Fix cache cypress hashfile path

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml
@@ -9,8 +9,8 @@ on: [pull_request, push]
 
 env:
   PLUGIN_NAME: notifications-dashboards
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  NOTIFICATIONS_PLUGIN_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.17.0'
+  NOTIFICATIONS_PLUGIN_VERSION: '2.17.0.0'
 
 jobs:
   Get-CI-Image-Tag:

--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -9,8 +9,8 @@ on: [pull_request, push]
 
 env:
   PLUGIN_NAME: notifications-dashboards
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  NOTIFICATIONS_PLUGIN_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.17.0'
+  NOTIFICATIONS_PLUGIN_VERSION: '2.17.0.0'
 
 jobs:
   tests:

--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           git config --system core.longpaths true
           subst 'X:' .
-      
+
       - name: enable long paths in git
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
@@ -170,7 +170,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ matrix.cypress_cache_folder }}
-          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('OpenSearch-Dashboards/plugins/dashboards-notifications/package.json') }}
 
       - name: Reset npm's script shell
         if: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
### Description
CI is failing on Cache Cypress step.
```
Error: The template is not valid. .github/workflows/dashboards-notifications-test-and-build-workflow.yml (Line: 173, Col: 16): hashFiles('**/package.json') couldn't finish within 120 seconds.
```
This PR adjusts the name of the hashfile so it's consistent with main
```
OpenSearch-Dashboards/plugins/dashboards-notifications/package.json
```
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
