### PR TITLE
Revert fit and finish changes from 2.17

### DIFF
--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -8,13 +8,13 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiPanel,
-  EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import React from 'react';
 
 interface ContentPanelProps {
   title?: string;
-  titleSize?: 'xs' | 's' | 'm';
+  titleSize?: 'xxxs' | 'xxs' | 'xs' | 's' | 'm' | 'l';
   total?: number;
   bodyStyles?: object;
   panelStyles?: object;
@@ -25,7 +25,7 @@ interface ContentPanelProps {
 
 const ContentPanel: React.SFC<ContentPanelProps> = ({
   title = '',
-  titleSize = 's',
+  titleSize = 'l',
   total = undefined,
   bodyStyles = {},
   panelStyles = {},
@@ -40,16 +40,16 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
       alignItems="center"
     >
       <EuiFlexItem>
-        <EuiText size={titleSize}>
-          <h2>
+        <EuiTitle size={titleSize}>
+          <h3>
             {title}
             {total !== undefined ? (
               <span
                 style={{ color: '#9f9f9f', fontWeight: 300 }}
               >{` (${total})`}</span>
             ) : null}
-          </h2>
-        </EuiText>
+          </h3>
+        </EuiTitle>
       </EuiFlexItem>
       {actions ? (
         <EuiFlexItem grow={false}>

--- a/public/components/ContentPanel/ContentPanel.tsx
+++ b/public/components/ContentPanel/ContentPanel.tsx
@@ -8,7 +8,7 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiPanel,
-  EuiTitle,
+  EuiText,
 } from '@elastic/eui';
 import React from 'react';
 
@@ -40,7 +40,7 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
       alignItems="center"
     >
       <EuiFlexItem>
-        <EuiTitle size={titleSize}>
+        <EuiText size={titleSize}>
           <h2>
             {title}
             {total !== undefined ? (
@@ -49,7 +49,7 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
               >{` (${total})`}</span>
             ) : null}
           </h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlexItem>
       {actions ? (
         <EuiFlexItem grow={false}>
@@ -70,7 +70,7 @@ const ContentPanel: React.SFC<ContentPanelProps> = ({
 
     <EuiHorizontalRule margin="s" className={horizontalRuleClassName} />
 
-    <div style={{ padding: '0px', ...bodyStyles }}>{children}</div>
+    <div style={{ padding: '0px 10px', ...bodyStyles }}>{children}</div>
   </EuiPanel>
 );
 

--- a/public/components/__tests__/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/__tests__/__snapshots__/ContentPanel.test.tsx.snap
@@ -11,13 +11,11 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h3
+        class="euiTitle euiTitle--large"
       >
-        <h2>
-          Testing
-        </h2>
-      </div>
+        Testing
+      </h3>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -59,13 +57,11 @@ exports[`<ContentPanel /> spec renders with empty actions 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h3
+        class="euiTitle euiTitle--large"
       >
-        <h2>
-          Testing
-        </h2>
-      </div>
+        Testing
+      </h3>
     </div>
   </div>
   <hr

--- a/public/components/__tests__/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/__tests__/__snapshots__/ContentPanel.test.tsx.snap
@@ -11,11 +11,13 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Testing
-      </h2>
+        <h2>
+          Testing
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -37,7 +39,7 @@ exports[`<ContentPanel /> spec renders the component 1`] = `
     class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
   />
   <div
-    style="padding: 0px;"
+    style="padding: 0px 10px;"
   >
     <div>
       Testing ContentPanel
@@ -57,18 +59,20 @@ exports[`<ContentPanel /> spec renders with empty actions 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Testing
-      </h2>
+        <h2>
+          Testing
+        </h2>
+      </div>
     </div>
   </div>
   <hr
     class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
   />
   <div
-    style="padding: 0px;"
+    style="padding: 0px 10px;"
   >
     <div>
       Testing ContentPanel

--- a/public/pages/Channels/Channels.tsx
+++ b/public/pages/Channels/Channels.tsx
@@ -277,11 +277,11 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
             appRightControls={headerControls}
             appLeftControls={[{ renderComponent: totalChannels }]}
           />
-          <ContentPanel panelStyles={{ padding: this.state.total < 1? '16px 16px 0px' : '16px' }}>
+          <ContentPanel>
             <div style={{ marginBottom: '10px' }}>
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 {channelControlsComponent}
-                <div style={{ marginLeft: '16px' }}>
+                <div style={{ marginLeft: '10px' }}>
                   {channelActionsComponent}
                 </div>
               </div>

--- a/public/pages/Channels/Channels.tsx
+++ b/public/pages/Channels/Channels.tsx
@@ -14,7 +14,6 @@ import {
   EuiTableSortingType,
   EuiTitle,
   SortDirection,
-  EuiText,
 } from '@elastic/eui';
 import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
 import { Pagination } from '@elastic/eui/src/components/basic_table/pagination_bar';
@@ -258,8 +257,8 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
       isSelectable={true}
       selection={selection}
       noItemsMessage={<EuiEmptyPrompt
-        title={<EuiText size="s"><h2>No channels to display</h2></EuiText>}
-        body={<EuiText size="s">"To send or receive notifications, you will need to create a notification channel."</EuiText>}
+        title={<h2>No channels to display</h2>}
+        body="To send or receive notifications, you will need to create a notification channel."
         actions={<EuiSmallButton href={`#${ROUTES.CREATE_CHANNEL}`}>
           Create channel
         </EuiSmallButton>} />}
@@ -310,7 +309,7 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
           }
           bodyStyles={{ padding: 'initial' }}
           title="Channels"
-          titleSize="s"
+          titleSize="m"
           total={this.state.total}
         >
           {channelControlsComponent}
@@ -319,7 +318,7 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
         </ContentPanel>
       )}
     </>
-
+    
     );
   }
 };

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ChannelControls /> spec renders the component 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
 >
   <div
     class="euiFlexItem"

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
@@ -91,14 +91,6 @@ exports[`<ChannelControls /> spec renders the component 1`] = `
           </button>
         </div>
       </div>
-    </div>
-  </div>
-  <div
-    class="euiFlexItem euiFlexItem--flexGrowZero"
-  >
-    <div
-      class="euiFilterGroup"
-    >
       <div
         class="euiPopover euiPopover--anchorDownCenter"
       >

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelDetails.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelDetails.test.tsx.snap
@@ -15,13 +15,11 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <div
-            class="euiText euiText--small"
+          <h1
+            class="euiTitle euiTitle--large"
           >
-            <h1>
-              -
-            </h1>
-          </div>
+            -
+          </h1>
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -57,13 +55,11 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <div
-          class="euiText euiText--small"
+        <h3
+          class="euiTitle euiTitle--small"
         >
-          <h2>
-            Name and description
-          </h2>
-        </div>
+          Name and description
+        </h3>
       </div>
     </div>
     <hr
@@ -157,13 +153,11 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <div
-          class="euiText euiText--small"
+        <h3
+          class="euiTitle euiTitle--small"
         >
-          <h2>
-            Configurations
-          </h2>
-        </div>
+          Configurations
+        </h3>
       </div>
     </div>
     <hr
@@ -191,13 +185,11 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <div
-            class="euiText euiText--small"
+          <h1
+            class="euiTitle euiTitle--large"
           >
-            <h1>
-              -
-            </h1>
-          </div>
+            -
+          </h1>
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -233,13 +225,11 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <div
-          class="euiText euiText--small"
+        <h3
+          class="euiTitle euiTitle--small"
         >
-          <h2>
-            Name and description
-          </h2>
-        </div>
+          Name and description
+        </h3>
       </div>
     </div>
     <hr
@@ -333,13 +323,11 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <div
-          class="euiText euiText--small"
+        <h3
+          class="euiTitle euiTitle--small"
         >
-          <h2>
-            Configurations
-          </h2>
-        </div>
+          Configurations
+        </h3>
       </div>
     </div>
     <hr
@@ -366,13 +354,11 @@ exports[`<ChannelDetails/> spec renders the component 1`] = `
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
-        <div
-          class="euiText euiText--small"
+        <h1
+          class="euiTitle euiTitle--large"
         >
-          <h1>
-            -
-          </h1>
-        </div>
+          -
+        </h1>
       </div>
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelDetails.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelDetails.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
 <div>
   <div
     class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-    style="padding: 0px 8px 0px 0px;"
+    style="max-width: 1316px;"
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <div
-        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
       >
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -25,12 +25,12 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
-          style="padding-top: 5px;"
+          style="padding-bottom: 5px;"
         />
       </div>
     </div>
     <div
-      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem"
@@ -48,6 +48,7 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
   />
   <div
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+    style="max-width: 1300px;"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -56,11 +57,13 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h2
-          class="euiTitle euiTitle--small"
+        <div
+          class="euiText euiText--small"
         >
-          Name and description
-        </h2>
+          <h2>
+            Name and description
+          </h2>
+        </div>
       </div>
     </div>
     <hr
@@ -145,6 +148,7 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
   />
   <div
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+    style="max-width: 1300px;"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -153,11 +157,13 @@ exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h2
-          class="euiTitle euiTitle--small"
+        <div
+          class="euiText euiText--small"
         >
-          Configurations
-        </h2>
+          <h2>
+            Configurations
+          </h2>
+        </div>
       </div>
     </div>
     <hr
@@ -174,13 +180,13 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
 <div>
   <div
     class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-    style="padding: 0px 8px 0px 0px;"
+    style="max-width: 1316px;"
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <div
-        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
       >
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -195,12 +201,12 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
-          style="padding-top: 5px;"
+          style="padding-bottom: 5px;"
         />
       </div>
     </div>
     <div
-      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem"
@@ -218,6 +224,7 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
   />
   <div
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+    style="max-width: 1300px;"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -226,11 +233,13 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h2
-          class="euiTitle euiTitle--small"
+        <div
+          class="euiText euiText--small"
         >
-          Name and description
-        </h2>
+          <h2>
+            Name and description
+          </h2>
+        </div>
       </div>
     </div>
     <hr
@@ -315,6 +324,7 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
   />
   <div
     class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+    style="max-width: 1300px;"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -323,11 +333,13 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h2
-          class="euiTitle euiTitle--small"
+        <div
+          class="euiText euiText--small"
         >
-          Configurations
-        </h2>
+          <h2>
+            Configurations
+          </h2>
+        </div>
       </div>
     </div>
     <hr
@@ -343,13 +355,13 @@ exports[`<ChannelDetails/> spec renders a specific channel 1`] = `
 exports[`<ChannelDetails/> spec renders the component 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-  style="padding: 0px 8px 0px 0px;"
+  style="max-width: 1316px;"
 >
   <div
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -364,12 +376,12 @@ exports[`<ChannelDetails/> spec renders the component 1`] = `
       </div>
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"
-        style="padding-top: 5px;"
+        style="padding-bottom: 5px;"
       />
     </div>
   </div>
   <div
-    class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
   >
     <div
       class="euiFlexItem"

--- a/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -195,14 +195,6 @@ exports[`<Channels/> spec renders the empty component 1`] = `
               </button>
             </div>
           </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexItem euiFlexItem--flexGrowZero"
-      >
-        <div
-          class="euiFilterGroup"
-        >
           <div
             class="euiPopover euiPopover--anchorDownCenter"
           >

--- a/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -11,16 +11,18 @@ exports[`<Channels/> spec renders the empty component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Channels
-        <span
-          style="color: rgb(159, 159, 159); font-weight: 300;"
-        >
-           (0)
-        </span>
-      </h2>
+        <h2>
+          Channels
+          <span
+            style="color: rgb(159, 159, 159); font-weight: 300;"
+          >
+             (0)
+          </span>
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -106,7 +108,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
     style="padding: initial;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem"

--- a/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -11,18 +11,16 @@ exports[`<Channels/> spec renders the empty component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h3
+        class="euiTitle euiTitle--medium"
       >
-        <h2>
-          Channels
-          <span
-            style="color: rgb(159, 159, 159); font-weight: 300;"
-          >
-             (0)
-          </span>
-        </h2>
-      </div>
+        Channels
+        <span
+          style="color: rgb(159, 159, 159); font-weight: 300;"
+        >
+           (0)
+        </span>
+      </h3>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -492,13 +490,11 @@ exports[`<Channels/> spec renders the empty component 1`] = `
                     <div
                       class="euiEmptyPrompt"
                     >
-                      <div
-                        class="euiText euiText--small euiTitle euiTitle--medium"
+                      <h2
+                        class="euiTitle euiTitle--medium"
                       >
-                        <h2>
-                          No channels to display
-                        </h2>
-                      </div>
+                        No channels to display
+                      </h2>
                       <span
                         class="euiTextColor euiTextColor--subdued"
                       >
@@ -508,11 +504,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
                         <div
                           class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--small"
-                          >
-                            "To send or receive notifications, you will need to create a notification channel."
-                          </div>
+                          To send or receive notifications, you will need to create a notification channel.
                         </div>
                       </span>
                       <div

--- a/public/pages/Channels/__tests__/__snapshots__/DetailsListModal.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/DetailsListModal.test.tsx.snap
@@ -82,13 +82,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                         <div
                           class="euiModalHeader__title"
                         >
-                          <div
-                            class="euiText euiText--small"
-                          >
-                            <h2>
-                              test header
-                            </h2>
-                          </div>
+                          test header
                         </div>
                       </div>
                       <div
@@ -319,13 +313,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                 <div
                                   class="euiModalHeader__title"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    <h2>
-                                      test header
-                                    </h2>
-                                  </div>
+                                  test header
                                 </div>
                               </div>
                               <div
@@ -488,13 +476,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                   <div
                                     class="euiModalHeader__title"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
-                                    >
-                                      <h2>
-                                        test header
-                                      </h2>
-                                    </div>
+                                    test header
                                   </div>
                                 </div>
                                 <div
@@ -657,13 +639,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                     <div
                                       class="euiModalHeader__title"
                                     >
-                                      <div
-                                        class="euiText euiText--small"
-                                      >
-                                        <h2>
-                                          test header
-                                        </h2>
-                                      </div>
+                                      test header
                                     </div>
                                   </div>
                                   <div
@@ -814,13 +790,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                       <div
                                         class="euiModalHeader__title"
                                       >
-                                        <div
-                                          class="euiText euiText--small"
-                                        >
-                                          <h2>
-                                            test header
-                                          </h2>
-                                        </div>
+                                        test header
                                       </div>
                                     </div>
                                     <div
@@ -1025,17 +995,7 @@ exports[`<DetailsListModal /> spec renders the component 1`] = `
                                   <div
                                     className="euiModalHeader__title"
                                   >
-                                    <EuiText
-                                      size="s"
-                                    >
-                                      <div
-                                        className="euiText euiText--small"
-                                      >
-                                        <h2>
-                                          test header
-                                        </h2>
-                                      </div>
-                                    </EuiText>
+                                    test header
                                   </div>
                                 </EuiModalHeaderTitle>
                               </div>

--- a/public/pages/Channels/__tests__/__snapshots__/DetailsTableModal.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/DetailsTableModal.test.tsx.snap
@@ -82,13 +82,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                         <div
                           class="euiModalHeader__title"
                         >
-                          <div
-                            class="euiText euiText--small"
-                          >
-                            <h2>
-                              test header
-                            </h2>
-                          </div>
+                          test header
                         </div>
                       </div>
                       <div
@@ -383,13 +377,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                 <div
                                   class="euiModalHeader__title"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    <h2>
-                                      test header
-                                    </h2>
-                                  </div>
+                                  test header
                                 </div>
                               </div>
                               <div
@@ -616,13 +604,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                   <div
                                     class="euiModalHeader__title"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
-                                    >
-                                      <h2>
-                                        test header
-                                      </h2>
-                                    </div>
+                                    test header
                                   </div>
                                 </div>
                                 <div
@@ -849,13 +831,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                     <div
                                       class="euiModalHeader__title"
                                     >
-                                      <div
-                                        class="euiText euiText--small"
-                                      >
-                                        <h2>
-                                          test header
-                                        </h2>
-                                      </div>
+                                      test header
                                     </div>
                                   </div>
                                   <div
@@ -1070,13 +1046,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                       <div
                                         class="euiModalHeader__title"
                                       >
-                                        <div
-                                          class="euiText euiText--small"
-                                        >
-                                          <h2>
-                                            test header
-                                          </h2>
-                                        </div>
+                                        test header
                                       </div>
                                     </div>
                                     <div
@@ -1345,17 +1315,7 @@ exports[`<DetailsTableModal /> spec renders headers 1`] = `
                                   <div
                                     className="euiModalHeader__title"
                                   >
-                                    <EuiText
-                                      size="s"
-                                    >
-                                      <div
-                                        className="euiText euiText--small"
-                                      >
-                                        <h2>
-                                          test header
-                                        </h2>
-                                      </div>
-                                    </EuiText>
+                                    test header
                                   </div>
                                 </EuiModalHeaderTitle>
                               </div>
@@ -1975,13 +1935,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                         <div
                           class="euiModalHeader__title"
                         >
-                          <div
-                            class="euiText euiText--small"
-                          >
-                            <h2>
-                              test header
-                            </h2>
-                          </div>
+                          test header
                         </div>
                       </div>
                       <div
@@ -2276,13 +2230,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                 <div
                                   class="euiModalHeader__title"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    <h2>
-                                      test header
-                                    </h2>
-                                  </div>
+                                  test header
                                 </div>
                               </div>
                               <div
@@ -2509,13 +2457,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                   <div
                                     class="euiModalHeader__title"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
-                                    >
-                                      <h2>
-                                        test header
-                                      </h2>
-                                    </div>
+                                    test header
                                   </div>
                                 </div>
                                 <div
@@ -2742,13 +2684,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                     <div
                                       class="euiModalHeader__title"
                                     >
-                                      <div
-                                        class="euiText euiText--small"
-                                      >
-                                        <h2>
-                                          test header
-                                        </h2>
-                                      </div>
+                                      test header
                                     </div>
                                   </div>
                                   <div
@@ -2963,13 +2899,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                       <div
                                         class="euiModalHeader__title"
                                       >
-                                        <div
-                                          class="euiText euiText--small"
-                                        >
-                                          <h2>
-                                            test header
-                                          </h2>
-                                        </div>
+                                        test header
                                       </div>
                                     </div>
                                     <div
@@ -3238,17 +3168,7 @@ exports[`<DetailsTableModal /> spec renders parameters 1`] = `
                                   <div
                                     className="euiModalHeader__title"
                                   >
-                                    <EuiText
-                                      size="s"
-                                    >
-                                      <div
-                                        className="euiText euiText--small"
-                                      >
-                                        <h2>
-                                          test header
-                                        </h2>
-                                      </div>
-                                    </EuiText>
+                                    test header
                                   </div>
                                 </EuiModalHeaderTitle>
                               </div>

--- a/public/pages/Channels/components/ChannelActions.tsx
+++ b/public/pages/Channels/components/ChannelActions.tsx
@@ -99,7 +99,6 @@ export function ChannelActions(props: ChannelActionsProps) {
             <EuiContextMenuItem
               key={params.label}
               disabled={params.disabled}
-              size="s"
               onClick={() => {
                 setIsPopoverOpen(false);
                 if (params.modal) {

--- a/public/pages/Channels/components/ChannelControls.tsx
+++ b/public/pages/Channels/components/ChannelControls.tsx
@@ -136,10 +136,6 @@ export const ChannelControls = (props: ChannelControlsProps) => {
               );
             })}
           </EuiPopover>
-        </EuiFilterGroup>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiFilterGroup>
           <EuiPopover
             button={
               <EuiSmallFilterButton

--- a/public/pages/Channels/components/ChannelControls.tsx
+++ b/public/pages/Channels/components/ChannelControls.tsx
@@ -96,7 +96,7 @@ export const ChannelControls = (props: ChannelControlsProps) => {
   }
 
   return (
-    <EuiFlexGroup gutterSize={'m'}>
+    <EuiFlexGroup>
       <EuiFlexItem>
         <EuiCompressedFieldSearch
           fullWidth={true}

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -33,7 +33,6 @@ import { ChannelDetailsActions } from './ChannelDetailsActions';
 import { ChannelSettingsDetails } from './ChannelSettingsDetails';
 import PageHeader from "../../../../components/PageHeader/PageHeader";
 import { TopNavControlButtonData } from '../../../../../../../src/plugins/navigation/public';
-import { getUseUpdatedUx } from '../../../../services/utils/constants';
 
 interface ChannelDetailsProps extends RouteComponentProps<{
   id: string
@@ -144,7 +143,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
     },
   ];
 
-  const actionsAndMuteComponent = <EuiFlexGroup gutterSize="s" alignItems="center">
+  const actionsAndMuteComponent = <EuiFlexGroup gutterSize="m" alignItems="flexEnd">
     <EuiFlexItem />
     <EuiFlexItem grow={false}>
       {channel && (
@@ -197,11 +196,10 @@ export function ChannelDetails(props: ChannelDetailsProps) {
       isDisabled: !channel?.is_enabled,
       run: sendTestMessage,
       label: 'Send test message',
-      fill: true,
     } as TopNavControlButtonData,
   ];
 
-  const badgeComponent = <EuiFlexItem grow={false} style={{ paddingTop: '5px' }}>
+  const badgeComponent = <EuiFlexItem grow={false} style={{ paddingBottom: 5 }}>
     {channel?.is_enabled === undefined ? null : channel.is_enabled ? (
       <EuiHealth color="success">Active</EuiHealth>
     ) : (
@@ -227,10 +225,10 @@ export function ChannelDetails(props: ChannelDetailsProps) {
           <EuiFlexGroup
           alignItems="center"
           gutterSize="m"
-          style={{ padding: '0px 8px 0px 0px' }}
+          style={{ maxWidth: 1316 }}
         >
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="m" alignItems="center">
+            <EuiFlexGroup gutterSize="m" alignItems="flexEnd">
               <EuiFlexItem grow={false}>
                 <EuiText size="s">
                   <h1>{channel?.name ?? '-'}</h1>
@@ -244,12 +242,12 @@ export function ChannelDetails(props: ChannelDetailsProps) {
         )}
       </PageHeader>
 
-      {!getUseUpdatedUx() && <EuiSpacer />}
-
+      <EuiSpacer />
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}
         title="Name and description"
         titleSize="s"
+        panelStyles={{ maxWidth: 1300 }}
       >
         <ChannelDetailItems listItems={nameList} />
       </ContentPanel>
@@ -260,6 +258,7 @@ export function ChannelDetails(props: ChannelDetailsProps) {
         bodyStyles={{ padding: 'initial' }}
         title="Configurations"
         titleSize="s"
+        panelStyles={{ maxWidth: 1300 }}
       >
         <ChannelSettingsDetails channel={channel} />
       </ContentPanel>

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -32,7 +32,6 @@ import { ChannelDetailItems } from './ChannelDetailItems';
 import { ChannelDetailsActions } from './ChannelDetailsActions';
 import { ChannelSettingsDetails } from './ChannelSettingsDetails';
 import PageHeader from "../../../../components/PageHeader/PageHeader";
-import { TopNavControlButtonData } from '../../../../../../../src/plugins/navigation/public';
 
 interface ChannelDetailsProps extends RouteComponentProps<{
   id: string
@@ -191,12 +190,19 @@ export function ChannelDetails(props: ChannelDetailsProps) {
       ),
     },
     {
-      controlType: 'button',
-      testId: 'send-test-message-button',
-      isDisabled: !channel?.is_enabled,
-      run: sendTestMessage,
-      label: 'Send test message',
-    } as TopNavControlButtonData,
+      renderComponent: (
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <EuiSmallButton
+            data-test-subj="send-test-message-button"
+            onClick={sendTestMessage}
+            style={{ marginLeft: '10px' }}
+            disabled={!channel?.is_enabled}
+          >
+            Send test message
+          </EuiSmallButton>
+        </div>
+      ),
+    },
   ];
 
   const badgeComponent = <EuiFlexItem grow={false} style={{ paddingBottom: 5 }}>

--- a/public/pages/Channels/components/details/ChannelDetails.tsx
+++ b/public/pages/Channels/components/details/ChannelDetails.tsx
@@ -11,6 +11,7 @@ import {
   EuiSmallButton,
   EuiSpacer,
   EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React, { useContext, useEffect, useState } from 'react';
@@ -236,9 +237,9 @@ export function ChannelDetails(props: ChannelDetailsProps) {
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="m" alignItems="flexEnd">
               <EuiFlexItem grow={false}>
-                <EuiText size="s">
+                <EuiTitle size="l">
                   <h1>{channel?.name ?? '-'}</h1>
-                </EuiText>
+                </EuiTitle>
               </EuiFlexItem>
               {badgeComponent}
             </EuiFlexGroup>

--- a/public/pages/Channels/components/details/ChannelDetailsActions.tsx
+++ b/public/pages/Channels/components/details/ChannelDetailsActions.tsx
@@ -101,7 +101,6 @@ export function ChannelDetailsActions(props: ChannelDetailsActionsProps) {
             <EuiContextMenuItem
               key={params.label}
               disabled={params.disabled}
-              size="s"
               onClick={() => {
                 setIsPopoverOpen(false);
                 if (params.modal) {

--- a/public/pages/Channels/components/modals/DeleteChannelModal.tsx
+++ b/public/pages/Channels/components/modals/DeleteChannelModal.tsx
@@ -48,14 +48,10 @@ export const DeleteChannelModal = (props: DeleteChannelModalProps) => {
     <EuiOverlayMask>
       <EuiModal onClose={props.onClose} maxWidth={500}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
-            <EuiText size="s">
-              <h2>{`Delete ${name}?`}</h2>
-            </EuiText>
-          </EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>{`Delete ${name}?`}</EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>
-          <EuiText size="s">{message}</EuiText>
+          <EuiText>{message}</EuiText>
           {num >= 2 && (
             <>
               <EuiSpacer />
@@ -63,7 +59,6 @@ export const DeleteChannelModal = (props: DeleteChannelModalProps) => {
                 <EuiText
                   key={`channel-list-item-${i}`}
                   style={{ marginLeft: 20 }}
-                  size="s"
                 >
                   <li>{channel.name}</li>
                 </EuiText>
@@ -71,7 +66,7 @@ export const DeleteChannelModal = (props: DeleteChannelModalProps) => {
             </>
           )}
           <EuiSpacer />
-          <EuiText size="s">
+          <EuiText>
             To confirm delete, type <i>delete</i> in the field.
           </EuiText>
           <EuiCompressedFieldText

--- a/public/pages/Channels/components/modals/DetailsListModal.tsx
+++ b/public/pages/Channels/components/modals/DetailsListModal.tsx
@@ -13,7 +13,6 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiTitle,
-  EuiText,
 } from '@elastic/eui';
 import React from 'react';
 import { ModalRootProps } from '../../../../components/Modal/ModalRoot';
@@ -31,11 +30,7 @@ export function DetailsListModal(props: DetailsListModalProps) {
       <EuiOverlayMask>
         <EuiModal onClose={props.onClose} maxWidth={800}>
           <EuiModalHeader>
-            <EuiModalHeaderTitle>
-              <EuiText size="s">
-                <h2>{props.header}</h2>
-              </EuiText>
-            </EuiModalHeaderTitle>
+            <EuiModalHeaderTitle>{props.header}</EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
             <EuiTitle size="xxs">

--- a/public/pages/Channels/components/modals/DetailsTableModal.tsx
+++ b/public/pages/Channels/components/modals/DetailsTableModal.tsx
@@ -13,7 +13,6 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiTableFieldDataColumnType,
-  EuiText,
 } from '@elastic/eui';
 import React from 'react';
 import { ModalRootProps } from '../../../../components/Modal/ModalRoot';
@@ -50,11 +49,7 @@ export function DetailsTableModal(props: DetailsTableModalProps) {
       <EuiOverlayMask>
         <EuiModal onClose={props.onClose} maxWidth={800}>
           <EuiModalHeader>
-            <EuiModalHeaderTitle>
-              <EuiText size="s">
-                <h2>{props.header}</h2>
-              </EuiText>
-            </EuiModalHeaderTitle>
+            <EuiModalHeaderTitle>{props.header}</EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
             <EuiInMemoryTable items={props.items} columns={columns} />

--- a/public/pages/Channels/components/modals/MuteChannelModal.tsx
+++ b/public/pages/Channels/components/modals/MuteChannelModal.tsx
@@ -37,14 +37,10 @@ export const MuteChannelModal = (props: MuteChannelModalProps) => {
     <EuiOverlayMask>
       <EuiModal onClose={props.onClose} maxWidth={500}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
-            <EuiText size="s">
-              <h2>{`Mute ${props.selected[0].name}?`}</h2>
-            </EuiText>
-          </EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>{`Mute ${props.selected[0].name}?`}</EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>
-          <EuiText size="s">
+          <EuiText>
             This channel will stop sending notifications to its recipients.
             However, the channel will remain available for selection.
           </EuiText>

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -373,15 +373,13 @@ export function CreateChannel(props: CreateChannelsProps) {
       <CreateChannelContext.Provider
         value={{ edit: props.edit, inputErrors, setInputErrors }}
       >
-        {!getUseUpdatedUx() && (
-          <>
-            <EuiText size="s">
-              <h1>{`${props.edit ? 'Edit' : 'Create'} channel`}</h1>
-            </EuiText>
-            <EuiSpacer />
-          </>
+       {!getUseUpdatedUx() && (
+          <EuiText size="s">
+            <h1>{`${props.edit ? 'Edit' : 'Create'} channel`}</h1>
+          </EuiText>
         )}
 
+        <EuiSpacer />
         <ChannelNamePanel
           name={name}
           setName={setName}

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -14,6 +14,7 @@ import {
   EuiCompressedSuperSelect,
   EuiSuperSelectOption,
   EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import queryString from 'query-string';
 import React, { createContext, useContext, useEffect, useState } from 'react';
@@ -374,9 +375,9 @@ export function CreateChannel(props: CreateChannelsProps) {
         value={{ edit: props.edit, inputErrors, setInputErrors }}
       >
        {!getUseUpdatedUx() && (
-          <EuiText size="s">
+          <EuiTitle size="l">
             <h1>{`${props.edit ? 'Edit' : 'Create'} channel`}</h1>
-          </EuiText>
+          </EuiTitle>
         )}
 
         <EuiSpacer />

--- a/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
@@ -11,11 +11,13 @@ exports[`<ChannelNamePanel/> spec renders errors 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Name and description
-      </h2>
+        <h2>
+          Name and description
+        </h2>
+      </div>
     </div>
   </div>
   <hr
@@ -118,11 +120,13 @@ exports[`<ChannelNamePanel/> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Name and description
-      </h2>
+        <h2>
+          Name and description
+        </h2>
+      </div>
     </div>
   </div>
   <hr

--- a/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
@@ -11,13 +11,11 @@ exports[`<ChannelNamePanel/> spec renders errors 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h3
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          Name and description
-        </h2>
-      </div>
+        Name and description
+      </h3>
     </div>
   </div>
   <hr
@@ -120,13 +118,11 @@ exports[`<ChannelNamePanel/> spec renders the component 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h3
+        class="euiTitle euiTitle--small"
       >
-        <h2>
-          Name and description
-        </h2>
-      </div>
+        Name and description
+      </h3>
     </div>
   </div>
   <hr

--- a/public/pages/CreateChannel/__tests__/__snapshots__/CreateChannel.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/CreateChannel.test.tsx.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CreateChannel/> spec renders the component 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Create channel
-  </h1>
-</div>
+  Create channel
+</h1>
 `;

--- a/public/pages/CreateChannel/components/modals/CreateRecipientGroupModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateRecipientGroupModal.tsx
@@ -13,7 +13,6 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiText,
 } from '@elastic/eui';
 import React, { useContext, useState } from 'react';
 import { CoreServicesContext } from '../../../../components/coreServices';
@@ -67,11 +66,7 @@ export function CreateRecipientGroupModal(
     <EuiOverlayMask>
       <EuiModal onClose={props.onClose} style={{ width: 650 }}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
-            <EuiText size="s">
-              <h2>Create recipient group</h2>
-            </EuiText>
-          </EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>Create recipient group</EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>

--- a/public/pages/CreateChannel/components/modals/CreateSESSenderModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateSESSenderModal.tsx
@@ -13,7 +13,6 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiText,
 } from '@elastic/eui';
 import React, { useContext, useState } from 'react';
 import { CoreServicesContext } from '../../../../components/coreServices';
@@ -71,11 +70,7 @@ export function CreateSESSenderModal(props: CreateSESSenderModalProps) {
     <EuiOverlayMask>
       <EuiModal onClose={props.onClose} style={{ width: 750 }}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
-            <EuiText size="s">
-              <h2>Create SES sender</h2>
-            </EuiText>
-          </EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>Create SES sender</EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>

--- a/public/pages/CreateChannel/components/modals/CreateSenderModal.tsx
+++ b/public/pages/CreateChannel/components/modals/CreateSenderModal.tsx
@@ -13,7 +13,6 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiText,
 } from '@elastic/eui';
 import React, { useContext, useState } from 'react';
 import { CoreServicesContext } from '../../../../components/coreServices';
@@ -69,11 +68,7 @@ export function CreateSenderModal(props: CreateSenderModalProps) {
     <EuiOverlayMask>
       <EuiModal onClose={props.onClose} style={{ width: 750 }}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
-            <EuiText size="s">
-              <h2>Create SMTP sender</h2>
-            </EuiText>
-          </EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>Create SMTP sender</EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>

--- a/public/pages/Emails/CreateRecipientGroup.tsx
+++ b/public/pages/Emails/CreateRecipientGroup.tsx
@@ -111,18 +111,17 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <>
-          <EuiText size="s">
-            <h1>{`${props.edit ? 'Edit' : 'Create'} recipient group`}</h1>
-          </EuiText>
-          <EuiSpacer />
-        </>
+        <EuiText size="s">
+          <h1>{`${props.edit ? 'Edit' : 'Create'} recipient group`}</h1>
+        </EuiText>
       )}
 
+      <EuiSpacer />
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}
         title="Configure recipient group"
         titleSize="s"
+        panelStyles={{ maxWidth: 1000 }}
       >
         <CreateRecipientGroupForm
           name={name}
@@ -138,7 +137,7 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
         />
       </ContentPanel>
       <EuiSpacer />
-      <EuiFlexGroup justifyContent="flexEnd">
+      <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
         <EuiFlexItem grow={false}>
           <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_GROUPS}`}>
             Cancel

--- a/public/pages/Emails/CreateRecipientGroup.tsx
+++ b/public/pages/Emails/CreateRecipientGroup.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import React, { useContext, useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -111,9 +111,9 @@ export function CreateRecipientGroup(props: CreateRecipientGroupProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
+        <EuiTitle size="l">
           <h1>{`${props.edit ? 'Edit' : 'Create'} recipient group`}</h1>
-        </EuiText>
+        </EuiTitle>
       )}
 
       <EuiSpacer />

--- a/public/pages/Emails/CreateSESSender.tsx
+++ b/public/pages/Emails/CreateSESSender.tsx
@@ -102,18 +102,17 @@ export function CreateSESSender(props: CreateSESSenderProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <>
-          <EuiText size="s">
-            <h1>{`${props.edit ? 'Edit' : 'Create'} SES sender`}</h1>
-          </EuiText>
-          <EuiSpacer />
-        </>
+        <EuiText size="s">
+          <h1>{`${props.edit ? 'Edit' : 'Create'} SES sender`}</h1>
+        </EuiText>
       )}
 
+      <EuiSpacer />
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}
         title="Configure sender"
         titleSize="s"
+        panelStyles={{ maxWidth: 1000 }}
       >
         <CreateSESSenderForm
           senderName={senderName}
@@ -130,7 +129,7 @@ export function CreateSESSender(props: CreateSESSenderProps) {
       </ContentPanel>
 
       <EuiSpacer />
-      <EuiFlexGroup justifyContent="flexEnd">
+      <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
         <EuiFlexItem grow={false}>
           <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_SENDERS}`}>
             Cancel

--- a/public/pages/Emails/CreateSESSender.tsx
+++ b/public/pages/Emails/CreateSESSender.tsx
@@ -9,7 +9,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import React, { useContext, useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -102,9 +102,9 @@ export function CreateSESSender(props: CreateSESSenderProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
+        <EuiTitle size="l">
           <h1>{`${props.edit ? 'Edit' : 'Create'} SES sender`}</h1>
-        </EuiText>
+        </EuiTitle>
       )}
 
       <EuiSpacer />

--- a/public/pages/Emails/CreateSender.tsx
+++ b/public/pages/Emails/CreateSender.tsx
@@ -9,7 +9,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import React, { useContext, useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -99,9 +99,9 @@ export function CreateSender(props: CreateSenderProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
+        <EuiTitle size="l">
           <h1>{`${props.edit ? 'Edit' : 'Create'} SMTP sender`}</h1>
-        </EuiText>
+        </EuiTitle>
       )}
 
       <EuiSpacer />

--- a/public/pages/Emails/CreateSender.tsx
+++ b/public/pages/Emails/CreateSender.tsx
@@ -99,18 +99,17 @@ export function CreateSender(props: CreateSenderProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <>
-          <EuiText size="s">
-            <h1>{`${props.edit ? 'Edit' : 'Create'} SMTP sender`}</h1>
-          </EuiText>
-          <EuiSpacer />
-        </>
+        <EuiText size="s">
+          <h1>{`${props.edit ? 'Edit' : 'Create'} SMTP sender`}</h1>
+        </EuiText>
       )}
 
+      <EuiSpacer />
       <ContentPanel
         bodyStyles={{ padding: 'initial' }}
         title="Configure sender"
         titleSize="s"
+        panelStyles={{ maxWidth: 1000 }}
       >
         <CreateSenderForm
           senderName={senderName}
@@ -129,7 +128,7 @@ export function CreateSender(props: CreateSenderProps) {
       </ContentPanel>
 
       <EuiSpacer />
-      <EuiFlexGroup justifyContent="flexEnd">
+      <EuiFlexGroup justifyContent="flexEnd" style={{ maxWidth: 1024 }}>
         <EuiFlexItem grow={false}>
           <EuiSmallButtonEmpty href={`#${ROUTES.EMAIL_SENDERS}`}>
             Cancel

--- a/public/pages/Emails/EmailGroups.tsx
+++ b/public/pages/Emails/EmailGroups.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import React, { useContext, useEffect } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { CoreServicesContext } from '../../components/coreServices';
@@ -29,9 +29,9 @@ export function EmailGroups(props: EmailGroupsProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
+        <EuiTitle size="l">
           <h1>Email recipient groups</h1>
-        </EuiText>
+        </EuiTitle>
       )}
 
       <EuiSpacer />

--- a/public/pages/Emails/EmailGroups.tsx
+++ b/public/pages/Emails/EmailGroups.tsx
@@ -29,14 +29,12 @@ export function EmailGroups(props: EmailGroupsProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <>
-          <EuiText size="s">
-            <h1>Email recipient groups</h1>
-          </EuiText>
-          <EuiSpacer />
-        </>
+        <EuiText size="s">
+          <h1>Email recipient groups</h1>
+        </EuiText>
       )}
 
+      <EuiSpacer />
       <RecipientGroupsTable coreContext={coreContext}
         notificationService={props.notificationService}
       />

--- a/public/pages/Emails/EmailSenders.tsx
+++ b/public/pages/Emails/EmailSenders.tsx
@@ -37,15 +37,13 @@ export function EmailSenders(props: EmailSendersProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <>
-          <EuiText size="s">
-            <h1>Email senders</h1>
-          </EuiText>
-          <EuiSpacer />
-        </>
+        <EuiText size="s">
+          <h1>Email senders</h1>
+        </EuiText>
       )}
       {mainStateContext.availableConfigTypes.includes('smtp_account') && (
         <>
+          <EuiSpacer />
           <SendersTable coreContext={coreContext}
             notificationService={props.notificationService}
           />

--- a/public/pages/Emails/EmailSenders.tsx
+++ b/public/pages/Emails/EmailSenders.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import React, { useContext, useEffect } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { CoreServicesContext } from '../../components/coreServices';
@@ -25,7 +25,7 @@ export function EmailSenders(props: EmailSendersProps) {
 
   // Call the hook to manage URL updates
   useUpdateUrlWithDataSourceProperties();
-
+  
   useEffect(() => {
     setBreadcrumbs([
       BREADCRUMBS.NOTIFICATIONS,
@@ -37,9 +37,9 @@ export function EmailSenders(props: EmailSendersProps) {
   return (
     <>
       {!getUseUpdatedUx() && (
-        <EuiText size="s">
+        <EuiTitle size="l">
           <h1>Email senders</h1>
-        </EuiText>
+        </EuiTitle>
       )}
       {mainStateContext.availableConfigTypes.includes('smtp_account') && (
         <>

--- a/public/pages/Emails/__tests__/__snapshots__/CreateRecipientGroup.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateRecipientGroup.test.tsx.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CreateRecipientGroup/> spec renders the component 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Create recipient group
-  </h1>
-</div>
+  Create recipient group
+</h1>
 `;

--- a/public/pages/Emails/__tests__/__snapshots__/CreateSESSender.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateSESSender.test.tsx.snap
@@ -1,31 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CreateSESSender/> spec handles failed requests 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Edit SES sender
-  </h1>
-</div>
+  Edit SES sender
+</h1>
 `;
 
 exports[`<CreateSESSender/> spec renders the component 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Create SES sender
-  </h1>
-</div>
+  Create SES sender
+</h1>
 `;
 
 exports[`<CreateSESSender/> spec renders the component for editing 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Edit SES sender
-  </h1>
-</div>
+  Edit SES sender
+</h1>
 `;

--- a/public/pages/Emails/__tests__/__snapshots__/CreateSender.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateSender.test.tsx.snap
@@ -1,31 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CreateSender/> spec handles failed requests 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Edit SMTP sender
-  </h1>
-</div>
+  Edit SMTP sender
+</h1>
 `;
 
 exports[`<CreateSender/> spec renders the component 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Create SMTP sender
-  </h1>
-</div>
+  Create SMTP sender
+</h1>
 `;
 
 exports[`<CreateSender/> spec renders the component for editing 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Edit SMTP sender
-  </h1>
-</div>
+  Edit SMTP sender
+</h1>
 `;

--- a/public/pages/Emails/__tests__/__snapshots__/EmailGroups.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/EmailGroups.test.tsx.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<EmailGroups/> spec renders the component 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Email recipient groups
-  </h1>
-</div>
+  Email recipient groups
+</h1>
 `;

--- a/public/pages/Emails/__tests__/__snapshots__/EmailSenders.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/EmailSenders.test.tsx.snap
@@ -1,21 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<EmailSenders/> spec renders the component with SMTP config type 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Email senders
-  </h1>
-</div>
+  Email senders
+</h1>
 `;
 
 exports[`<EmailSenders/> spec renders the component without SMTP config type 1`] = `
-<div
-  class="euiText euiText--small"
+<h1
+  class="euiTitle euiTitle--large"
 >
-  <h1>
-    Email senders
-  </h1>
-</div>
+  Email senders
+</h1>
 `;

--- a/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
@@ -11,16 +11,18 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Recipient groups
-        <span
-          style="color: rgb(159, 159, 159); font-weight: 300;"
-        >
-           (0)
-        </span>
-      </h2>
+        <h2>
+          Recipient groups
+          <span
+            style="color: rgb(159, 159, 159); font-weight: 300;"
+          >
+             (0)
+          </span>
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
@@ -11,18 +11,16 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h3
+        class="euiTitle euiTitle--medium"
       >
-        <h2>
-          Recipient groups
-          <span
-            style="color: rgb(159, 159, 159); font-weight: 300;"
-          >
-             (0)
-          </span>
-        </h2>
-      </div>
+        Recipient groups
+        <span
+          style="color: rgb(159, 159, 159); font-weight: 300;"
+        >
+           (0)
+        </span>
+      </h3>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -370,13 +368,11 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
                     <div
                       class="euiEmptyPrompt"
                     >
-                      <div
-                        class="euiText euiText--small euiTitle euiTitle--medium"
+                      <h2
+                        class="euiTitle euiTitle--medium"
                       >
-                        <h2>
-                          No recipient groups to display
-                        </h2>
-                      </div>
+                        No recipient groups to display
+                      </h2>
                       <span
                         class="euiTextColor euiTextColor--subdued"
                       >
@@ -386,11 +382,7 @@ exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
                         <div
                           class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--small"
-                          >
-                            Use an email group to manage a list of email addresses you frequently send at a time. You can select recipient groups when configuring email channels.
-                          </div>
+                          Use an email group to manage a list of email addresses you frequently send at a time. You can select recipient groups when configuring email channels.
                         </div>
                       </span>
                       <div

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
               class="euiPopover__anchor"
             >
               <button
-                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon euiFilterButton--noGrow"
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
                 type="button"
               >
                 <span
@@ -181,7 +181,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
                     />
                   </svg>
                   <span
-                    class="euiButtonEmpty__text euiFilterButton__text-hasNotification"
+                    class="euiButtonEmpty__text"
                   >
                     <span
                       class="euiFilterButton__textShift"
@@ -189,12 +189,6 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
                       title="Encryption method"
                     >
                       Encryption method
-                    </span>
-                    <span
-                      aria-label="0 available filters"
-                      class="euiNotificationBadge euiNotificationBadge--medium euiNotificationBadge--subdued euiFilterButton__notification"
-                    >
-                      0
                     </span>
                   </span>
                 </span>

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
@@ -11,16 +11,18 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        SMTP senders
-        <span
-          style="color: rgb(159, 159, 159); font-weight: 300;"
-        >
-           (0)
-        </span>
-      </h2>
+        <h2>
+          SMTP senders
+          <span
+            style="color: rgb(159, 159, 159); font-weight: 300;"
+          >
+             (0)
+          </span>
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -105,7 +107,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
     style="padding: initial;"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
         class="euiFlexItem"

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
@@ -11,18 +11,16 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
-        class="euiText euiText--small"
+      <h3
+        class="euiTitle euiTitle--medium"
       >
-        <h2>
-          SMTP senders
-          <span
-            style="color: rgb(159, 159, 159); font-weight: 300;"
-          >
-             (0)
-          </span>
-        </h2>
-      </div>
+        SMTP senders
+        <span
+          style="color: rgb(159, 159, 159); font-weight: 300;"
+        >
+           (0)
+        </span>
+      </h3>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -472,13 +470,11 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
                     <div
                       class="euiEmptyPrompt"
                     >
-                      <div
-                        class="euiText euiText--small euiTitle euiTitle--medium"
+                      <h2
+                        class="euiTitle euiTitle--medium"
                       >
-                        <h2>
-                          No SMTP senders to display
-                        </h2>
-                      </div>
+                        No SMTP senders to display
+                      </h2>
                       <span
                         class="euiTextColor euiTextColor--subdued"
                       >
@@ -488,11 +484,7 @@ exports[`<SendersTable /> spec renders empty state 1`] = `
                         <div
                           class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--small"
-                          >
-                            Set up an outbound email server by creating a sender. You will select a sender when configuring email channels.
-                          </div>
+                          Set up an outbound email server by creating a sender. You will select a sender when configuring email channels.
                         </div>
                       </span>
                       <div

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
           class="euiPopover__anchor"
         >
           <button
-            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton-hasNotification euiFilterButton--hasIcon euiFilterButton--noGrow"
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiFilterButton euiFilterButton--hasIcon euiFilterButton--noGrow"
             type="button"
           >
             <span
@@ -78,7 +78,7 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
                 />
               </svg>
               <span
-                class="euiButtonEmpty__text euiFilterButton__text-hasNotification"
+                class="euiButtonEmpty__text"
               >
                 <span
                   class="euiFilterButton__textShift"
@@ -86,12 +86,6 @@ exports[`<SendersTableControls /> spec renders the component 1`] = `
                   title="Encryption method"
                 >
                   Encryption method
-                </span>
-                <span
-                  aria-label="0 available filters"
-                  class="euiNotificationBadge euiNotificationBadge--medium euiNotificationBadge--subdued euiFilterButton__notification"
-                >
-                  0
                 </span>
               </span>
             </span>

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SendersTableControls /> spec renders the component 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
 >
   <div
     class="euiFlexItem"

--- a/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
+++ b/public/pages/Emails/components/forms/CreateRecipientGroupForm.tsx
@@ -60,7 +60,7 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
         />
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="m" />
       <EuiCompressedFormRow
         label={
           <span>
@@ -84,7 +84,7 @@ export function CreateRecipientGroupForm(props: CreateRecipientGroupFormProps) {
         </>
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="m" />
       <EuiCompressedFormRow
         label="Emails"
         style={{ maxWidth: '650px' }}

--- a/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSESSenderForm.tsx
@@ -59,7 +59,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
         />
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="m" />
       <EuiCompressedFormRow
         label="Email address"
         style={{ maxWidth: '650px' }}
@@ -82,7 +82,7 @@ export function CreateSESSenderForm(props: CreateSESSenderFormProps) {
         />
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: '658px' }}>
         <EuiFlexItem grow={6}>
           <EuiCompressedFormRow

--- a/public/pages/Emails/components/forms/CreateSenderForm.tsx
+++ b/public/pages/Emails/components/forms/CreateSenderForm.tsx
@@ -74,7 +74,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
         />
       </EuiCompressedFormRow>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="s" style={{ maxWidth: '658px' }}>
         <EuiFlexItem grow={4}>
           <EuiCompressedFormRow
@@ -141,7 +141,7 @@ export function CreateSenderForm(props: CreateSenderFormProps) {
         </EuiFlexItem>
       </EuiFlexGroup>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="m" />
       <EuiCompressedFormRow
         label="Encryption method"
         style={{ maxWidth: '650px' }}

--- a/public/pages/Emails/components/modals/DeleteRecipientGroupModal.tsx
+++ b/public/pages/Emails/components/modals/DeleteRecipientGroupModal.tsx
@@ -50,14 +50,10 @@ export const DeleteRecipientGroupModal = (
     <EuiOverlayMask>
       <EuiModal onClose={props.onClose} maxWidth={500}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
-            <EuiText size="s">
-              <h2>{`Delete ${name}?`}</h2>
-            </EuiText>
-          </EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>{`Delete ${name}?`}</EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>
-          <EuiText size="s">{message}</EuiText>
+          <EuiText>{message}</EuiText>
           {num >= 2 && (
             <>
               <EuiSpacer />
@@ -72,7 +68,7 @@ export const DeleteRecipientGroupModal = (
             </>
           )}
           <EuiSpacer />
-          <EuiText size="s">
+          <EuiText>
             To confirm delete, type <i>delete</i> in the field.
           </EuiText>
           <EuiCompressedFieldText

--- a/public/pages/Emails/components/modals/DeleteSenderModal.tsx
+++ b/public/pages/Emails/components/modals/DeleteSenderModal.tsx
@@ -47,14 +47,10 @@ export const DeleteSenderModal = (props: DeleteSenderModalProps) => {
     <EuiOverlayMask>
       <EuiModal onClose={props.onClose} maxWidth={500}>
         <EuiModalHeader>
-          <EuiModalHeaderTitle>
-            <EuiText size="s">
-              <h2>{`Delete ${name}?`}</h2>
-            </EuiText>
-          </EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>{`Delete ${name}?`}</EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>
-          <EuiText size="s">{message}</EuiText>
+          <EuiText>{message}</EuiText>
           {num >= 2 && (
             <>
               <EuiSpacer />
@@ -62,7 +58,6 @@ export const DeleteSenderModal = (props: DeleteSenderModalProps) => {
                 <EuiText
                   key={`sender-list-item-${i}`}
                   style={{ marginLeft: 20 }}
-                  size="s"
                 >
                   <li>{sender.name}</li>
                 </EuiText>
@@ -70,7 +65,7 @@ export const DeleteSenderModal = (props: DeleteSenderModalProps) => {
             </>
           )}
           <EuiSpacer />
-          <EuiText size="s">
+          <EuiText>
             To confirm delete, type <i>delete</i> in the field.
           </EuiText>
           <EuiCompressedFieldText

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -18,7 +18,6 @@ import {
   EuiTableSortingType,
   EuiTitle,
   SortDirection,
-  EuiText,
 } from '@elastic/eui';
 import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
 import { Pagination } from '@elastic/eui/src/components/basic_table/pagination_bar';
@@ -287,12 +286,8 @@ export class RecipientGroupsTable extends Component<
       isSelectable={true}
       selection={selection}
       noItemsMessage={<EuiEmptyPrompt
-        title={<EuiText size="s"><h2>No recipient groups to display</h2></EuiText>}
-        body={
-          <EuiText size="s">
-            Use an email group to manage a list of email addresses you frequently send at a time. You can select recipient groups when configuring email channels.
-          </EuiText>
-        }
+        title={<h2>No recipient groups to display</h2>}
+        body="Use an email group to manage a list of email addresses you frequently send at a time. You can select recipient groups when configuring email channels."
         actions={<EuiSmallButton href={`#${ROUTES.CREATE_RECIPIENT_GROUP}`}>
           Create recipient group
         </EuiSmallButton>} />}
@@ -335,7 +330,6 @@ export class RecipientGroupsTable extends Component<
                           <EuiContextMenuItem
                             key={action.label}
                             disabled={action.disabled}
-                            size="s"
                             onClick={() => {
                               this.setState({ isPopoverOpen: false });
                               if (action.modal) {
@@ -407,7 +401,7 @@ export class RecipientGroupsTable extends Component<
             }
             bodyStyles={{ padding: 'initial' }}
             title="Recipient groups"
-            titleSize="s"
+            titleSize="m"
             total={this.state.total}
           >
             {searchComponent}

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -308,12 +308,8 @@ export class RecipientGroupsTable extends Component<
               appRightControls={headerControls}
               appLeftControls={[{ renderComponent: totalEmailGroups }]}
             />
-            <ContentPanel
-              panelStyles={{
-                padding: this.state.total < 1 ? '16px 16px 0px' : '16px',
-              }}
-            >
-              <EuiFlexGroup gutterSize={'m'}>
+            <ContentPanel>
+              <EuiFlexGroup>
                 <EuiFlexItem>
                   {searchComponent}
                 </EuiFlexItem>
@@ -325,6 +321,7 @@ export class RecipientGroupsTable extends Component<
                         iconType="arrowDown"
                         iconSide="right"
                         onClick={this.togglePopover}
+                        style={{ marginLeft: '10px' }} // Ensure spacing is correct
                       >
                         Actions
                       </EuiSmallButton>

--- a/public/pages/Emails/components/tables/SESSendersTable.tsx
+++ b/public/pages/Emails/components/tables/SESSendersTable.tsx
@@ -16,7 +16,6 @@ import {
   EuiTableFieldDataColumnType,
   EuiTableSortingType,
   SortDirection,
-  EuiText,
 } from '@elastic/eui';
 import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
 import { Pagination } from '@elastic/eui/src/components/basic_table/pagination_bar';
@@ -224,8 +223,8 @@ export class SESSendersTable extends Component<
       isSelectable={true}
       selection={selection}
       noItemsMessage={<EuiEmptyPrompt
-        title={<EuiText size="s"><h2>No SES senders to display</h2></EuiText>}
-        body={<EuiText size="s">Set up an outbound email server by creating a sender. You will select a sender when configuring email channels.</EuiText>}
+        title={<h2>No SES senders to display</h2>}
+        body="Set up an outbound email server by creating a sender. You will select a sender when configuring email channels."
         actions={<EuiSmallButton href={`#${ROUTES.CREATE_SES_SENDER}`}>
           Create SES sender
         </EuiSmallButton>} />}
@@ -260,7 +259,7 @@ export class SESSendersTable extends Component<
             }
             bodyStyles={{ padding: 'initial' }}
             title="SES senders"
-            titleSize="s"
+            titleSize="m"
             total={this.state.total}
           >
             <EuiFlexGroup>
@@ -289,7 +288,6 @@ export class SESSendersTable extends Component<
                         <EuiContextMenuItem
                           key={action.label}
                           disabled={action.disabled}
-                          size="s"
                           onClick={() => {
                             this.setState({ isPopoverOpen: false });
                             if (action.modal) {
@@ -362,7 +360,7 @@ export class SESSendersTable extends Component<
             }
             bodyStyles={{ padding: 'initial' }}
             title="SES senders"
-            titleSize="s"
+            titleSize="m"
             total={this.state.total}
           >
             {searchComponent}

--- a/public/pages/Emails/components/tables/SESSendersTable.tsx
+++ b/public/pages/Emails/components/tables/SESSendersTable.tsx
@@ -245,9 +245,6 @@ export class SESSendersTable extends Component<
       <>
         {getUseUpdatedUx() ? (
           <ContentPanel
-            panelStyles={{
-              padding: this.state.total < 1 ? '16px 16px 0px' : '16px',
-            }}
             actions={
               <ContentPanelActions
                 actions={[
@@ -266,7 +263,7 @@ export class SESSendersTable extends Component<
             titleSize="s"
             total={this.state.total}
           >
-            <EuiFlexGroup gutterSize={'m'}>
+            <EuiFlexGroup>
               <EuiFlexItem>
                 {searchComponent}
               </EuiFlexItem>
@@ -278,6 +275,7 @@ export class SESSendersTable extends Component<
                       iconType="arrowDown"
                       iconSide="right"
                       onClick={this.togglePopover}
+                      style={{ marginLeft: '10px' }} // Ensure spacing is correct
                     >
                       Actions
                     </EuiSmallButton>

--- a/public/pages/Emails/components/tables/SendersTable.tsx
+++ b/public/pages/Emails/components/tables/SendersTable.tsx
@@ -269,9 +269,6 @@ export class SendersTable extends Component<
       <>
         {getUseUpdatedUx() ? (
           <ContentPanel
-            panelStyles={{
-              padding: this.state.total < 1 ? '16px 16px 0px' : '16px',
-            }}
             actions={
               <ContentPanelActions
                 actions={[
@@ -290,7 +287,7 @@ export class SendersTable extends Component<
             titleSize="s"
             total={this.state.total}
           >
-            <EuiFlexGroup gutterSize={'m'}>
+            <EuiFlexGroup>
               <EuiFlexItem>
                 {senderControlComponent}
               </EuiFlexItem>
@@ -302,6 +299,7 @@ export class SendersTable extends Component<
                       iconType="arrowDown"
                       iconSide="right"
                       onClick={this.togglePopover}
+                      style={{ marginLeft: '10px' }} // Ensure spacing is correct
                     >
                       Actions
                     </EuiSmallButton>

--- a/public/pages/Emails/components/tables/SendersTable.tsx
+++ b/public/pages/Emails/components/tables/SendersTable.tsx
@@ -15,7 +15,6 @@ import {
   EuiTableFieldDataColumnType,
   EuiTableSortingType,
   SortDirection,
-  EuiText,
 } from '@elastic/eui';
 import { Criteria } from '@elastic/eui/src/components/basic_table/basic_table';
 import { Pagination } from '@elastic/eui/src/components/basic_table/pagination_bar';
@@ -251,12 +250,8 @@ export class SendersTable extends Component<
       isSelectable={true}
       selection={selection}
       noItemsMessage={<EuiEmptyPrompt
-        title={<EuiText size="s"><h2>No SMTP senders to display</h2></EuiText>}
-        body={
-          <EuiText size="s">
-            Set up an outbound email server by creating a sender. You will select a sender when configuring email channels.
-          </EuiText>
-        }
+        title={<h2>No SMTP senders to display</h2>}
+        body="Set up an outbound email server by creating a sender. You will select a sender when configuring email channels."
         actions={<EuiSmallButton href={`#${ROUTES.CREATE_SENDER}`}>
           Create SMTP sender
         </EuiSmallButton>} />}
@@ -284,7 +279,7 @@ export class SendersTable extends Component<
             }
             bodyStyles={{ padding: 'initial' }}
             title="SMTP senders"
-            titleSize="s"
+            titleSize="m"
             total={this.state.total}
           >
             <EuiFlexGroup>
@@ -313,7 +308,6 @@ export class SendersTable extends Component<
                         <EuiContextMenuItem
                           key={action.label}
                           disabled={action.disabled}
-                          size="s"
                           onClick={() => {
                             this.setState({ isPopoverOpen: false });
                             if (action.modal) {
@@ -386,7 +380,7 @@ export class SendersTable extends Component<
             }
             bodyStyles={{ padding: 'initial' }}
             title="SMTP senders"
-            titleSize="s"
+            titleSize="m"
             total={this.state.total}
           >
             {senderControlComponent}

--- a/public/pages/Emails/components/tables/SendersTableControls.tsx
+++ b/public/pages/Emails/components/tables/SendersTableControls.tsx
@@ -63,7 +63,7 @@ export const SendersTableControls = (props: SendersTableControlsProps) => {
   }
 
   return (
-    <EuiFlexGroup gutterSize={'m'}>
+    <EuiFlexGroup>
       <EuiFlexItem>
         <EuiCompressedFieldSearch
           data-test-subj="senders-table-search-input"

--- a/public/pages/Emails/components/tables/SendersTableControls.tsx
+++ b/public/pages/Emails/components/tables/SendersTableControls.tsx
@@ -78,9 +78,6 @@ export const SendersTableControls = (props: SendersTableControlsProps) => {
           <EuiPopover
             button={
               <EuiSmallFilterButton
-                numFilters={
-                  encryptionItems.filter((item) => item.checked === 'on').length
-                }
                 iconType="arrowDown"
                 grow={false}
                 onClick={() =>

--- a/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
+++ b/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
@@ -116,16 +116,18 @@ exports[`<Main /> spec renders the component 1`] = `
         <div
           class="euiFlexItem"
         >
-          <h2
-            class="euiTitle euiTitle--small"
+          <div
+            class="euiText euiText--small"
           >
-            Channels
-            <span
-              style="color: rgb(159, 159, 159); font-weight: 300;"
-            >
-               (0)
-            </span>
-          </h2>
+            <h2>
+              Channels
+              <span
+                style="color: rgb(159, 159, 159); font-weight: 300;"
+              >
+                 (0)
+              </span>
+            </h2>
+          </div>
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -211,7 +213,7 @@ exports[`<Main /> spec renders the component 1`] = `
         style="padding: initial;"
       >
         <div
-          class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionRow euiFlexGroup--responsive"
+          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
           <div
             class="euiFlexItem"

--- a/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
+++ b/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
@@ -300,14 +300,6 @@ exports[`<Main /> spec renders the component 1`] = `
                   </button>
                 </div>
               </div>
-            </div>
-          </div>
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <div
-              class="euiFilterGroup"
-            >
               <div
                 class="euiPopover euiPopover--anchorDownCenter"
               >

--- a/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
+++ b/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
@@ -116,18 +116,16 @@ exports[`<Main /> spec renders the component 1`] = `
         <div
           class="euiFlexItem"
         >
-          <div
-            class="euiText euiText--small"
+          <h3
+            class="euiTitle euiTitle--medium"
           >
-            <h2>
-              Channels
-              <span
-                style="color: rgb(159, 159, 159); font-weight: 300;"
-              >
-                 (0)
-              </span>
-            </h2>
-          </div>
+            Channels
+            <span
+              style="color: rgb(159, 159, 159); font-weight: 300;"
+            >
+               (0)
+            </span>
+          </h3>
         </div>
         <div
           class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -597,13 +595,11 @@ exports[`<Main /> spec renders the component 1`] = `
                         <div
                           class="euiEmptyPrompt"
                         >
-                          <div
-                            class="euiText euiText--small euiTitle euiTitle--medium"
+                          <h2
+                            class="euiTitle euiTitle--medium"
                           >
-                            <h2>
-                              No channels to display
-                            </h2>
-                          </div>
+                            No channels to display
+                          </h2>
                           <span
                             class="euiTextColor euiTextColor--subdued"
                           >
@@ -613,11 +609,7 @@ exports[`<Main /> spec renders the component 1`] = `
                             <div
                               class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--small"
-                              >
-                                "To send or receive notifications, you will need to create a notification channel."
-                              </div>
+                              To send or receive notifications, you will need to create a notification channel.
                             </div>
                           </span>
                           <div


### PR DESCRIPTION
### Description
Revert fit and finish changes from 2.17 branch
This PR reverts commits:
- https://github.com/opensearch-project/dashboards-notifications/pull/275
- https://github.com/opensearch-project/dashboards-notifications/pull/269
- https://github.com/opensearch-project/dashboards-notifications/pull/268
- https://github.com/opensearch-project/dashboards-notifications/pull/259

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
