### PR TITLE
Fix typo in recipient

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
 
       - name: Check out the notifications repo
         uses: actions/checkout@v2

--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
 
       # This is a hack, but this step creates a link to the X: mounted drive, which makes the path
       # short enough to work on Windows

--- a/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
+++ b/public/pages/Emails/components/tables/RecipientGroupsTable.tsx
@@ -276,7 +276,7 @@ export class RecipientGroupsTable extends Component<
       placeholder="Search"
       onSearch={this.onSearchChange} />;
 
-    const createRecepientButton = <EuiSmallButton fill href={`#${ROUTES.CREATE_RECIPIENT_GROUP}`}>
+    const createRecipientButton = <EuiSmallButton fill href={`#${ROUTES.CREATE_RECIPIENT_GROUP}`}>
       Create recipient group
     </EuiSmallButton>;
 
@@ -403,7 +403,7 @@ export class RecipientGroupsTable extends Component<
                     ),
                   },
                   {
-                    component: createRecepientButton,
+                    component: createRecipientButton,
                   },
                 ]}
               />

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -121,7 +121,7 @@ export class notificationsDashboardsPlugin
 
       core.application.register({
         id: `email_groups`,
-        title: 'Email recepient groups',
+        title: 'Email recipient groups',
         order: 9090,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         updater$: this.appStateUpdater,


### PR DESCRIPTION
### Description

Found this typo while using playgrounds. Updated text from `recepient` to `recipient`. 

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
