### PR TITLE
[Backport 3.1] Avoid refetching channel config on every keystroke for name update

### DIFF
--- a/.cypress/integration/channels.spec.js
+++ b/.cypress/integration/channels.spec.js
@@ -289,10 +289,10 @@ describe('Test channel details', () => {
         'opensearchDashboards'
       )}/app/notifications-dashboards#channels`
     );
-    cy.contains('Test webhook channel').click();
   });
 
   it('displays channel details', async () => {
+    cy.contains('Test webhook channel').click();
     cy.contains('custom-webhook-test-url.com').should('exist');
     cy.contains('test-path').should('exist');
     cy.contains('8888').should('exist');
@@ -302,6 +302,7 @@ describe('Test channel details', () => {
   });
 
   it('mutes and unmutes channels', async () => {
+    cy.contains('Test webhook channel').click();
     cy.contains('Mute channel').click({ force: true });
     cy.get('[data-test-subj="mute-channel-modal-mute-button"]').click({
       force: true,
@@ -315,10 +316,19 @@ describe('Test channel details', () => {
   });
 
   it('edits channels', () => {
+    cy.contains('Test webhook channel').click();
     cy.contains('Actions').click({ force: true });
     cy.contains('Edit').click({ force: true });
     cy.contains('Edit channel').should('exist');
     cy.get('.euiText').contains('Custom webhook').should('exist');
+
+    // Test editing the name
+    cy.get('[placeholder="Enter channel name"]')
+      .clear()
+      .type('Updated webhook channel name');
+    cy.wait(delay);
+
+    // Test editing the description
     cy.get(
       '[data-test-subj="create-channel-description-input"]'
     ).type('{selectall}{backspace}Updated custom webhook description');
@@ -326,14 +336,16 @@ describe('Test channel details', () => {
     cy.contains('Save').click({ force: true });
 
     cy.contains('successfully updated.').should('exist');
+    cy.contains('Updated webhook channel name').should('exist');
     cy.contains('Updated custom webhook description').should('exist');
   })
 
   it('deletes channels', async () => {
+    cy.contains('Updated webhook channel name').click();
     cy.contains('Actions').click({ force: true });
     cy.contains('Delete').click({ force: true });
     cy.get('input[placeholder="delete"]').type('delete');
-    cy.get('[data-test-subj="delete-channel-modal-delete-button"]').click({force: true})
+    cy.get('[data-test-subj="delete-channel-modal-delete-button"]').click({ force: true })
     cy.contains('successfully deleted.').should('exist');
     cy.contains('Test slack channel').should('exist');
   })

--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -9,9 +9,7 @@ on: [pull_request, push]
 
 env:
   PLUGIN_NAME: notifications-dashboards
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
   NOTIFICATIONS_PLUGIN_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.1.0-SNAPSHOT'
 
 jobs:
   tests:
@@ -67,6 +65,24 @@ jobs:
           git config --system core.longpaths true
         shell: bash
 
+      - name: Checkout Notification Dashboards plugin
+        uses: actions/checkout@v2
+        with:
+          path: dashboards-notifications
+
+      - name: Get plugin version from opensearch_dashboards.json
+        id: plugin_version
+        working-directory: dashboards-notifications
+        run: |
+          PLUGIN_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")
+          echo "Plugin version: $PLUGIN_VERSION"
+          # Extract major.minor version (e.g., 3.3.0 -> 3.3)
+          BRANCH_VERSION=$(echo $PLUGIN_VERSION | cut -d. -f1,2)
+          echo "Branch version: $BRANCH_VERSION"
+          echo "OPENSEARCH_DASHBOARDS_VERSION=$BRANCH_VERSION" >> $GITHUB_OUTPUT
+          echo "OPENSEARCH_VERSION=$PLUGIN_VERSION-SNAPSHOT" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Check out the notifications repo
         uses: actions/checkout@v2
         with:
@@ -82,21 +98,16 @@ jobs:
               brew install coreutils
           fi
           cd notifications/notifications
-          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} -x integTest -x jacocoTestReport &
+          ./gradlew run -Dopensearch.version=${{ steps.plugin_version.outputs.OPENSEARCH_VERSION }} -x integTest -x jacocoTestReport &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
         shell: bash
         env:
           _JAVA_OPTIONS: ${{ matrix.os_java_options }}
-
-      - name: Checkout Notification Dashboards plugin
-        uses: actions/checkout@v2
-        with:
-          path: dashboards-notifications
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
         with:
           repository: opensearch-project/Opensearch-Dashboards
-          ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
+          ref: ${{ steps.plugin_version.outputs.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
 
       - name: Setup Node

--- a/public/pages/CreateChannel/CreateChannel.tsx
+++ b/public/pages/CreateChannel/CreateChannel.tsx
@@ -142,6 +142,15 @@ export function CreateChannel(props: CreateChannelsProps) {
     roleArn: [],
   });
 
+  // Initial load: fetch channel data and set up page
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    if (props.edit) {
+      getChannel();
+    }
+  }, []);
+
+  // Update breadcrumbs when name changes
   useEffect(() => {
     const { edit } = props;
     const breadcrumbs = [
@@ -156,12 +165,8 @@ export function CreateChannel(props: CreateChannelsProps) {
     } else {
       breadcrumbs.push(BREADCRUMBS.CREATE_CHANNEL)
     }
-    window.scrollTo(0, 0);
     setBreadcrumbs(breadcrumbs);
-    if (props.edit) {
-      getChannel();
-    }
-  }, [name, getUseUpdatedUx()]);
+  }, [name, props.edit]);
 
   const getChannel = async () => {
     const id = props.match.params.id;


### PR DESCRIPTION
### Description
Backport #393 to 3.1

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
