### PR TITLE
Increased wait time by 2 more min before running cypress tests

### DIFF
--- a/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notifications-test-and-build-workflow.yml
@@ -165,8 +165,8 @@ jobs:
 
       - name: Add sleep to wait for bundle build completion
         run: |
-          sleep 300
-        # sleep two more minutes to make sure all the bundles have been built.
+          sleep 420
+        # sleep 7 minutes to make sure all the bundles have been built, else the tests fail
         shell: bash
 
       - name: Install Cypress


### PR DESCRIPTION
### Description
The OSD bundles are not built completely by the time we start testing. Increasing wait time to help fix this

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
