### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/public/components/__tests__/__snapshots__/ContentPanel.test.tsx.snap
+++ b/public/components/__tests__/__snapshots__/ContentPanel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ContentPanel /> spec renders the component 1`] = `
 <div

--- a/public/components/__tests__/__snapshots__/ContentPanelActions.test.tsx.snap
+++ b/public/components/__tests__/__snapshots__/ContentPanelActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ContentPanelActions /> spec renders the component 1`] = `
 <div

--- a/public/pages/Channels/__tests__/ChannelActions.test.tsx
+++ b/public/pages/Channels/__tests__/ChannelActions.test.tsx
@@ -127,6 +127,6 @@ describe('<ChannelActions/> spec', () => {
 
     const muteButton = utils.getByText('Unmute');
     fireEvent.click(muteButton);
-    expect(updateConfig).toBeCalled();
+    expect(updateConfig).toHaveBeenCalled();
   });
 });

--- a/public/pages/Channels/__tests__/ChannelControls.test.tsx
+++ b/public/pages/Channels/__tests__/ChannelControls.test.tsx
@@ -40,7 +40,7 @@ describe('<ChannelControls /> spec', () => {
     const input = utils.getByPlaceholderText('Search');
 
     fireEvent.change(input, { target: { value: 'test' } });
-    expect(onSearchChange).toBeCalledWith('test');
+    expect(onSearchChange).toHaveBeenCalledWith('test');
   });
 
   it('changes filters', () => {
@@ -57,13 +57,13 @@ describe('<ChannelControls /> spec', () => {
     );
     fireEvent.click(utils.getByText('Status'));
     fireEvent.click(utils.getByText('Active'));
-    expect(onFiltersChange).toBeCalledWith({ state: 'true' });
+    expect(onFiltersChange).toHaveBeenCalledWith({ state: 'true' });
 
     fireEvent.click(utils.getByText('Type'));
     fireEvent.click(utils.getByText('Email'));
     fireEvent.click(utils.getByText('Chime'));
-    expect(onFiltersChange).toBeCalledWith({ type: ['email', 'chime'] });
+    expect(onFiltersChange).toHaveBeenCalledWith({ type: ['email', 'chime'] });
 
-    expect(onFiltersChange).toBeCalledTimes(3);
+    expect(onFiltersChange).toHaveBeenCalledTimes(3);
   });
 });

--- a/public/pages/Channels/__tests__/Channels.test.tsx
+++ b/public/pages/Channels/__tests__/Channels.test.tsx
@@ -55,13 +55,13 @@ describe('<Channels/> spec', () => {
       </MainContext.Provider>
     );
 
-    await waitFor(() => expect(getChannels).toBeCalled());
+    await waitFor(() => expect(getChannels).toHaveBeenCalled());
 
     const input = utils.getByPlaceholderText('Search');
     fireEvent.change(input, { target: { value: 'test-query' } });
 
     await waitFor(() =>
-      expect(getChannels).toBeCalledWith(
+      expect(getChannels).toHaveBeenCalledWith(
         expect.objectContaining({ query: 'test-query' })
       )
     );

--- a/public/pages/Channels/__tests__/MuteChannelModal.test.tsx
+++ b/public/pages/Channels/__tests__/MuteChannelModal.test.tsx
@@ -64,7 +64,7 @@ describe('<MuteChannelModal /> spec', () => {
       </CoreServicesContext.Provider>
     );
     utils.getByText('Mute').click();
-    await waitFor(() => expect(setSelected).toBeCalled())
+    await waitFor(() => expect(setSelected).toHaveBeenCalled())
   });
 
   it('handles failures', async () => {

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelActions.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelActions/> spec clicks in the popover 1`] = `
 <div

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelControls /> spec renders the component 1`] = `
 <div

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelDetails.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelDetails.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelDetails/> spec handles a non-existing channel 1`] = `
 <div>

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelDetailsActions.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelDetailsActions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelDetailsActions /> spec opens popover 1`] = `
 <div

--- a/public/pages/Channels/__tests__/__snapshots__/ChannelSettingsDetails.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/ChannelSettingsDetails.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelSettingsDetails /> spec renders Chime channel 1`] = `
 <div>

--- a/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Channels/> spec renders the empty component 1`] = `
 <div

--- a/public/pages/Channels/__tests__/__snapshots__/DeleteChannelModal.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/DeleteChannelModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteChannelModal /> spec deletes channels 1`] = `null`;
 

--- a/public/pages/Channels/__tests__/__snapshots__/DetailsListModal.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/DetailsListModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DetailsListModal /> spec renders the component 1`] = `
 <DetailsListModal

--- a/public/pages/Channels/__tests__/__snapshots__/DetailsTableModal.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/DetailsTableModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DetailsTableModal /> spec renders headers 1`] = `
 <DetailsTableModal

--- a/public/pages/Channels/__tests__/__snapshots__/MuteChannelModal.test.tsx.snap
+++ b/public/pages/Channels/__tests__/__snapshots__/MuteChannelModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<MuteChannelModal /> spec handles failures 1`] = `null`;
 

--- a/public/pages/CreateChannel/__tests__/ChannelNamePanel.test.tsx
+++ b/public/pages/CreateChannel/__tests__/ChannelNamePanel.test.tsx
@@ -47,7 +47,7 @@ describe('<ChannelNamePanel/> spec', () => {
     const nameField = utils.getByPlaceholderText('Enter channel name');
     fireEvent.change(nameField, { target: { value: 'test name' } });
     fireEvent.blur(nameField);
-    expect(setName).toBeCalledWith('test name');
+    expect(setName).toHaveBeenCalledWith('test name');
   });
 
   it('renders errors', () => {

--- a/public/pages/CreateChannel/__tests__/ChimeSettings.test.tsx
+++ b/public/pages/CreateChannel/__tests__/ChimeSettings.test.tsx
@@ -71,7 +71,7 @@ describe('<ChimeSettings /> spec', () => {
     const input = utils.getByLabelText('Webhook URL');
     fireEvent.change(input, { target: { value: 'https://hooks.chime.aws/incomingwebhooks/sample_chime_url?token=123456' } });
     fireEvent.blur(input);
-    expect(setChimeWebhook).toBeCalledWith('https://hooks.chime.aws/incomingwebhooks/sample_chime_url?token=123456');
-    expect(setInputErrors).toBeCalled();
+    expect(setChimeWebhook).toHaveBeenCalledWith('https://hooks.chime.aws/incomingwebhooks/sample_chime_url?token=123456');
+    expect(setInputErrors).toHaveBeenCalled();
   });
 });

--- a/public/pages/CreateChannel/__tests__/CreateChannel.test.tsx
+++ b/public/pages/CreateChannel/__tests__/CreateChannel.test.tsx
@@ -121,13 +121,13 @@ describe('<CreateChannel/> spec', () => {
     );
 
     await waitFor(() => {
-      expect(getSlackChannel).toBeCalled();
+      expect(getSlackChannel).toHaveBeenCalled();
     });
 
     utilsSlack.getByTestId('create-channel-create-button').click();
     utilsSlack.getByTestId('create-channel-send-test-message-button').click();
     await waitFor(() => {
-      expect(updateConfigSuccess).toBeCalled();
+      expect(updateConfigSuccess).toHaveBeenCalled();
     });
   });
 
@@ -158,12 +158,12 @@ describe('<CreateChannel/> spec', () => {
     );
 
     await waitFor(() => {
-      expect(getChimeChannel).toBeCalled();
+      expect(getChimeChannel).toHaveBeenCalled();
     });
 
     utilsChime.getByTestId('create-channel-create-button').click();
     await waitFor(() => {
-      expect(updateConfigFailure).toBeCalled();
+      expect(updateConfigFailure).toHaveBeenCalled();
     });
   });
 
@@ -194,12 +194,12 @@ describe('<CreateChannel/> spec', () => {
     );
 
     await waitFor(() => {
-      expect(getMicrosoftTeamsChannel).toBeCalled();
+      expect(getMicrosoftTeamsChannel).toHaveBeenCalled();
     });
 
     utilsMicrosoftTeams.getByTestId('create-channel-create-button').click();
     await waitFor(() => {
-      expect(updateConfigFailure).toBeCalled();
+      expect(updateConfigFailure).toHaveBeenCalled();
     });
   });
 
@@ -234,12 +234,12 @@ describe('<CreateChannel/> spec', () => {
     );
 
     await waitFor(() => {
-      expect(getEmailChannel).toBeCalled();
+      expect(getEmailChannel).toHaveBeenCalled();
     });
 
     utilsEmail.getByTestId('create-channel-create-button').click();
     await waitFor(() => {
-      expect(updateConfigSuccess).toBeCalled();
+      expect(updateConfigSuccess).toHaveBeenCalled();
     });
   });
 
@@ -274,7 +274,7 @@ describe('<CreateChannel/> spec', () => {
     );
 
     await waitFor(() => {
-      expect(getEmailChannel).toBeCalled();
+      expect(getEmailChannel).toHaveBeenCalled();
     });
   });
 
@@ -305,12 +305,12 @@ describe('<CreateChannel/> spec', () => {
     );
 
     await waitFor(() => {
-      expect(getWebhookChannel).toBeCalled();
+      expect(getWebhookChannel).toHaveBeenCalled();
     });
 
     utilsWebhook.getByTestId('create-channel-create-button').click();
     await waitFor(() => {
-      expect(updateConfigSuccess).toBeCalled();
+      expect(updateConfigSuccess).toHaveBeenCalled();
     });
   });
 
@@ -339,12 +339,12 @@ describe('<CreateChannel/> spec', () => {
     );
 
     await waitFor(() => {
-      expect(getSNSChannel).toBeCalled();
+      expect(getSNSChannel).toHaveBeenCalled();
     });
 
     utilsSNS.getByTestId('create-channel-create-button').click();
     await waitFor(() => {
-      expect(updateConfigSuccess).toBeCalled();
+      expect(updateConfigSuccess).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/CreateChannel/__tests__/CreateSESSenderModal.test.tsx
+++ b/public/pages/CreateChannel/__tests__/CreateSESSenderModal.test.tsx
@@ -77,7 +77,7 @@ describe('<CreateSESSenderModal/> spec', () => {
 
     utils.getByText('Create').click();
     await waitFor(() => {
-      expect(createConfig).toBeCalled();
+      expect(createConfig).toHaveBeenCalled();
     });
   });
 
@@ -115,7 +115,7 @@ describe('<CreateSESSenderModal/> spec', () => {
 
     utils.getByText('Create').click();
     await waitFor(() => {
-      expect(createConfig).toBeCalled();
+      expect(createConfig).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/CreateChannel/__tests__/CreateSenderModal.test.tsx
+++ b/public/pages/CreateChannel/__tests__/CreateSenderModal.test.tsx
@@ -66,7 +66,7 @@ describe('<CreateSenderModal/> spec', () => {
 
     utils.getByText('Create').click();
     await waitFor(() => {
-      expect(createConfig).toBeCalled();
+      expect(createConfig).toHaveBeenCalled();
     });
   });
 
@@ -98,7 +98,7 @@ describe('<CreateSenderModal/> spec', () => {
 
     utils.getByText('Create').click();
     await waitFor(() => {
-      expect(createConfig).toBeCalled();
+      expect(createConfig).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/CreateChannel/__tests__/CustomWebhookSettings.test.tsx
+++ b/public/pages/CreateChannel/__tests__/CustomWebhookSettings.test.tsx
@@ -53,8 +53,8 @@ describe('<CustomWebhookSettings /> spec', () => {
     const hostInput = customURLUtils.getByTestId('custom-webhook-host-input');
     fireEvent.change(hostInput, { target: { value: 'https://test-url' } });
     fireEvent.blur(hostInput);
-    expect(setCustomURLHost).toBeCalledWith('https://test-url');
-    expect(setInputErrors).toBeCalled();
+    expect(setCustomURLHost).toHaveBeenCalledWith('https://test-url');
+    expect(setInputErrors).toHaveBeenCalled();
 
     const webhookURLUtils = render(
       <CreateChannelContext.Provider
@@ -87,13 +87,13 @@ describe('<CustomWebhookSettings /> spec', () => {
     const urlInput = customURLUtils.getByTestId('custom-webhook-url-input');
     fireEvent.change(urlInput, { target: { value: 'https://test-url' } });
     fireEvent.blur(urlInput);
-    expect(setWebhookURL).toBeCalledWith('https://test-url');
-    expect(setInputErrors).toBeCalled();
+    expect(setWebhookURL).toHaveBeenCalledWith('https://test-url');
+    expect(setInputErrors).toHaveBeenCalled();
 
     const pathInput = customURLUtils.getByTestId('custom-webhook-path-input');
     fireEvent.change(pathInput, { target: { value: 'https://test-url' } });
     fireEvent.blur(pathInput);
-    expect(setCustomURLPath).toBeCalledWith('https://test-url');
+    expect(setCustomURLPath).toHaveBeenCalledWith('https://test-url');
   });
 
   it('renders the component with errors', () => {

--- a/public/pages/CreateChannel/__tests__/EmailSettings.test.tsx
+++ b/public/pages/CreateChannel/__tests__/EmailSettings.test.tsx
@@ -71,8 +71,8 @@ describe('<EmailSettings /> spec', () => {
     utils.getByText('Create recipient group').click();
 
     await waitFor(() => {
-      expect(getSenders).toBeCalled();
-      expect(getRecipientGroups).toBeCalled();
+      expect(getSenders).toHaveBeenCalled();
+      expect(getRecipientGroups).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/CreateChannel/__tests__/MicrosoftTeamsSettings.test.tsx
+++ b/public/pages/CreateChannel/__tests__/MicrosoftTeamsSettings.test.tsx
@@ -71,7 +71,7 @@ describe('<MicrosoftTeamsSettings /> spec', () => {
     const input = utils.getByLabelText('Webhook URL');
     fireEvent.change(input, { target: { value: 'https://test-microsoftTeams-url' } });
     fireEvent.blur(input);
-    expect(setMicrosoftTeamsWebhook).toBeCalledWith('https://test-microsoftTeams-url');
-    expect(setInputErrors).toBeCalled();
+    expect(setMicrosoftTeamsWebhook).toHaveBeenCalledWith('https://test-microsoftTeams-url');
+    expect(setInputErrors).toHaveBeenCalled();
   });
 });

--- a/public/pages/CreateChannel/__tests__/SNSSettings.test.tsx
+++ b/public/pages/CreateChannel/__tests__/SNSSettings.test.tsx
@@ -86,13 +86,13 @@ describe('<SNSSettings /> spec', () => {
     const topicArnInput = utils.getByTestId('sns-settings-topic-arn-input');
     fireEvent.change(topicArnInput, { target: { value: 'test-update-topic' } });
     fireEvent.blur(topicArnInput);
-    expect(setTopicArn).toBeCalledWith('test-update-topic');
-    expect(setInputErrors).toBeCalled();
+    expect(setTopicArn).toHaveBeenCalledWith('test-update-topic');
+    expect(setInputErrors).toHaveBeenCalled();
 
     const roleArnInput = utils.getByTestId('sns-settings-role-arn-input');
     fireEvent.change(roleArnInput, { target: { value: 'test-update-role' } });
     fireEvent.blur(roleArnInput);
-    expect(setRoleArn).toBeCalledWith('test-update-role');
-    expect(setInputErrors).toBeCalled();
+    expect(setRoleArn).toHaveBeenCalledWith('test-update-role');
+    expect(setInputErrors).toHaveBeenCalled();
   });
 });

--- a/public/pages/CreateChannel/__tests__/SlackSettings.test.tsx
+++ b/public/pages/CreateChannel/__tests__/SlackSettings.test.tsx
@@ -71,7 +71,7 @@ describe('<SlackSettings /> spec', () => {
     const input = utils.getByLabelText('Slack webhook URL');
     fireEvent.change(input, { target: { value: 'https://test-slack-url' } });
     fireEvent.blur(input);
-    expect(setSlackWebhook).toBeCalledWith('https://test-slack-url');
-    expect(setInputErrors).toBeCalled();
+    expect(setSlackWebhook).toHaveBeenCalledWith('https://test-slack-url');
+    expect(setInputErrors).toHaveBeenCalled();
   });
 });

--- a/public/pages/CreateChannel/__tests__/WebhookHeaders.test.tsx
+++ b/public/pages/CreateChannel/__tests__/WebhookHeaders.test.tsx
@@ -62,12 +62,12 @@ describe('<WebhookHeaders /> spec', () => {
     fireEvent.change(parameterUtils.getByDisplayValue('key1'), {
       target: { value: 'test-key' },
     });
-    expect(setHeaders).toBeCalledWith([{ key: 'test-key', value: 'value1' }]);
+    expect(setHeaders).toHaveBeenCalledWith([{ key: 'test-key', value: 'value1' }]);
 
     fireEvent.change(parameterUtils.getByDisplayValue('value1'), {
       target: { value: 'test-value' },
     });
-    expect(setHeaders).toBeCalledWith([
+    expect(setHeaders).toHaveBeenCalledWith([
       { key: 'test-key', value: 'test-value' },
     ]);
 

--- a/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChannelNamePanel/> spec renders errors 1`] = `
 <div

--- a/public/pages/CreateChannel/__tests__/__snapshots__/ChimeSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/ChimeSettings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ChimeSettings /> spec renders the component 1`] = `
 <div

--- a/public/pages/CreateChannel/__tests__/__snapshots__/CreateChannel.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/CreateChannel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateChannel/> spec renders the component 1`] = `
 <div

--- a/public/pages/CreateChannel/__tests__/__snapshots__/CreateRecipientGroupModal.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/CreateRecipientGroupModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateRecipientGroupModal/> spec renders the component 1`] = `null`;
 

--- a/public/pages/CreateChannel/__tests__/__snapshots__/CreateSESSenderModal.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/CreateSESSenderModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateSESSenderModal/> spec renders the component 1`] = `null`;
 

--- a/public/pages/CreateChannel/__tests__/__snapshots__/CreateSenderModal.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/CreateSenderModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateSenderModal/> spec renders the component 1`] = `null`;
 

--- a/public/pages/CreateChannel/__tests__/__snapshots__/CustomWebhookSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/CustomWebhookSettings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CustomWebhookSettings /> spec renders the component 1`] = `
 <div

--- a/public/pages/CreateChannel/__tests__/__snapshots__/MicrosoftTeamsSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/MicrosoftTeamsSettings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<MicrosoftTeamsSettings /> spec renders the component 1`] = `
 <div

--- a/public/pages/CreateChannel/__tests__/__snapshots__/SNSSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/SNSSettings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SNSSettings /> spec renders and edits fields 1`] = `
 <div

--- a/public/pages/CreateChannel/__tests__/__snapshots__/SlackSettings.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/SlackSettings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SlackSettings /> spec renders the component 1`] = `
 <div

--- a/public/pages/CreateChannel/__tests__/__snapshots__/WebhookHeaders.test.tsx.snap
+++ b/public/pages/CreateChannel/__tests__/__snapshots__/WebhookHeaders.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<WebhookHeaders /> spec renders the component 1`] = `
 <h4

--- a/public/pages/CreateChannel/__tests__/helper.test.ts
+++ b/public/pages/CreateChannel/__tests__/helper.test.ts
@@ -119,7 +119,7 @@ describe('constructs and deconstructs webhook objects', () => {
     expect(webhookParams).toEqual([]);
     expect(webhookHeaders).toEqual([]);
 
-    expect(console.error).toBeCalled();
+    expect(console.error).toHaveBeenCalled();
   });
 });
 

--- a/public/pages/Emails/__tests__/CreateRecipientGroup.test.tsx
+++ b/public/pages/Emails/__tests__/CreateRecipientGroup.test.tsx
@@ -53,7 +53,7 @@ describe('<CreateRecipientGroup/> spec', () => {
 
     utils.getByText('Save').click();
     await waitFor(() => {
-      expect(updateConfig).toBeCalled();
+      expect(updateConfig).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/Emails/__tests__/CreateRecipientGroupForm.test.tsx
+++ b/public/pages/Emails/__tests__/CreateRecipientGroupForm.test.tsx
@@ -49,7 +49,7 @@ describe('<CreateRecipientGroupForm/> spec', () => {
     );
     fireEvent.change(nameInput, { target: { value: 'test name' } });
     fireEvent.blur(nameInput);
-    expect(setName).toBeCalledWith('test name');
+    expect(setName).toHaveBeenCalledWith('test name');
 
     const descriptionInput = utils.getByTestId(
       'create-recipient-group-form-description-input'
@@ -58,7 +58,7 @@ describe('<CreateRecipientGroupForm/> spec', () => {
       target: { value: 'test description' },
     });
     fireEvent.blur(descriptionInput);
-    expect(setDescription).toBeCalledWith('test description');
+    expect(setDescription).toHaveBeenCalledWith('test description');
   });
 
   it('changes email options', () => {

--- a/public/pages/Emails/__tests__/CreateSESSender.test.tsx
+++ b/public/pages/Emails/__tests__/CreateSESSender.test.tsx
@@ -64,7 +64,7 @@ describe('<CreateSESSender/> spec', () => {
 
     utils.getByText('Save').click();
     await waitFor(() => {
-      expect(updateConfig).toBeCalled();
+      expect(updateConfig).toHaveBeenCalled();
     });
   });
 
@@ -77,7 +77,7 @@ describe('<CreateSESSender/> spec', () => {
 
     utils.getByText('Save').click();
     await waitFor(() => {
-      expect(updateConfig).toBeCalled();
+      expect(updateConfig).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/Emails/__tests__/CreateSESSenderForm.test.tsx
+++ b/public/pages/Emails/__tests__/CreateSESSenderForm.test.tsx
@@ -48,26 +48,26 @@ describe('<CreateSESSenderForm/> spec', () => {
     const nameInput = utils.getByTestId('create-ses-sender-form-name-input');
     fireEvent.change(nameInput, { target: { value: 'test name' } });
     fireEvent.blur(nameInput);
-    expect(setSenderName).toBeCalledWith('test name');
+    expect(setSenderName).toHaveBeenCalledWith('test name');
 
     const emailInput = utils.getByTestId('create-ses-sender-form-email-input');
     fireEvent.change(emailInput, { target: { value: 'test@email.com' } });
     fireEvent.blur(emailInput);
-    expect(setEmail).toBeCalledWith('test@email.com');
+    expect(setEmail).toHaveBeenCalledWith('test@email.com');
 
     const roleArnInput = utils.getByTestId(
       'create-ses-sender-form-role-arn-input'
     );
     fireEvent.change(roleArnInput, { target: { value: 'test-role' } });
     fireEvent.blur(roleArnInput);
-    expect(setRoleArn).toBeCalledWith('test-role');
+    expect(setRoleArn).toHaveBeenCalledWith('test-role');
 
     const awsRegionInput = utils.getByTestId(
       'create-ses-sender-form-aws-region-input'
     );
     fireEvent.change(awsRegionInput, { target: { value: 'us-east-2' } });
     fireEvent.blur(awsRegionInput);
-    expect(setAwsRegion).toBeCalledWith('us-east-2');
+    expect(setAwsRegion).toHaveBeenCalledWith('us-east-2');
   });
 
   it('renders errors', () => {

--- a/public/pages/Emails/__tests__/CreateSender.test.tsx
+++ b/public/pages/Emails/__tests__/CreateSender.test.tsx
@@ -56,7 +56,7 @@ describe('<CreateSender/> spec', () => {
 
     utils.getByText('Save').click();
     await waitFor(() => {
-      expect(updateConfig).toBeCalled();
+      expect(updateConfig).toHaveBeenCalled();
     });
   });
 
@@ -69,7 +69,7 @@ describe('<CreateSender/> spec', () => {
 
     utils.getByText('Save').click();
     await waitFor(() => {
-      expect(updateConfig).toBeCalled();
+      expect(updateConfig).toHaveBeenCalled();
     });
   });
 });

--- a/public/pages/Emails/__tests__/CreateSenderForm.test.tsx
+++ b/public/pages/Emails/__tests__/CreateSenderForm.test.tsx
@@ -42,22 +42,22 @@ describe('<CreateSenderForm/> spec', () => {
     const nameInput = utils.getByTestId('create-sender-form-name-input');
     fireEvent.change(nameInput, { target: { value: 'test name' } });
     fireEvent.blur(nameInput);
-    expect(setSenderName).toBeCalledWith('test name');
+    expect(setSenderName).toHaveBeenCalledWith('test name');
 
     const emailInput = utils.getByTestId('create-sender-form-email-input');
     fireEvent.change(emailInput, { target: { value: 'test@email.com' } });
     fireEvent.blur(emailInput);
-    expect(setEmail).toBeCalledWith('test@email.com');
+    expect(setEmail).toHaveBeenCalledWith('test@email.com');
 
     const hostInput = utils.getByTestId('create-sender-form-host-input');
     fireEvent.change(hostInput, { target: { value: 'host.com' } });
     fireEvent.blur(hostInput);
-    expect(setHost).toBeCalledWith('host.com');
+    expect(setHost).toHaveBeenCalledWith('host.com');
 
     const portInput = utils.getByTestId('create-sender-form-port-input');
     fireEvent.change(portInput, { target: { value: '23' } });
     fireEvent.blur(portInput);
-    expect(setPort).toBeCalledWith('23');
+    expect(setPort).toHaveBeenCalledWith('23');
   });
 
   it('renders errors', () => {

--- a/public/pages/Emails/__tests__/RecipientGroupsTable.test.tsx
+++ b/public/pages/Emails/__tests__/RecipientGroupsTable.test.tsx
@@ -50,13 +50,13 @@ describe('<RecipientGroupsTable /> spec', () => {
       </ServicesContext.Provider>
     );
 
-    await waitFor(() => expect(getRecipientGroups).toBeCalled());
+    await waitFor(() => expect(getRecipientGroups).toHaveBeenCalled());
 
     const input = utils.getByPlaceholderText('Search');
     fireEvent.change(input, { target: { value: 'test-query' } });
 
     await waitFor(() =>
-      expect(getRecipientGroups).toBeCalledWith(
+      expect(getRecipientGroups).toHaveBeenCalledWith(
         expect.objectContaining({ query: 'test-query' })
       )
     );

--- a/public/pages/Emails/__tests__/SendersTable.test.tsx
+++ b/public/pages/Emails/__tests__/SendersTable.test.tsx
@@ -50,13 +50,13 @@ describe('<SendersTable /> spec', () => {
       </ServicesContext.Provider>
     );
 
-    await waitFor(() => expect(getSenders).toBeCalled());
+    await waitFor(() => expect(getSenders).toHaveBeenCalled());
 
     const input = utils.getByPlaceholderText('Search');
     fireEvent.change(input, { target: { value: 'test-query' } });
 
     await waitFor(() =>
-      expect(getSenders).toBeCalledWith(
+      expect(getSenders).toHaveBeenCalledWith(
         expect.objectContaining({ query: 'test-query' })
       )
     );

--- a/public/pages/Emails/__tests__/SendersTableControls.test.tsx
+++ b/public/pages/Emails/__tests__/SendersTableControls.test.tsx
@@ -45,7 +45,7 @@ describe('<SendersTableControls /> spec', () => {
     const input = utils.getByPlaceholderText('Search');
 
     fireEvent.change(input, { target: { value: 'test' } });
-    expect(onSearchChange).toBeCalledWith('test');
+    expect(onSearchChange).toHaveBeenCalledWith('test');
   });
 
   it('changes filters', () => {
@@ -63,6 +63,6 @@ describe('<SendersTableControls /> spec', () => {
     fireEvent.click(utils.getByText('Encryption method'));
     fireEvent.click(utils.getByText('STARTTLS'));
     fireEvent.click(utils.getByText('None'));
-    expect(onFiltersChange).toBeCalledWith({ encryptionMethod: ["start_tls", "none"] });
+    expect(onFiltersChange).toHaveBeenCalledWith({ encryptionMethod: ["start_tls", "none"] });
   });
 });

--- a/public/pages/Emails/__tests__/__snapshots__/CreateRecipientGroup.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateRecipientGroup.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateRecipientGroup/> spec renders the component 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/CreateRecipientGroupForm.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateRecipientGroupForm.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateRecipientGroupForm/> spec render errors 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/CreateSESSender.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateSESSender.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateSESSender/> spec handles failed requests 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/CreateSESSenderForm.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateSESSenderForm.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateSESSenderForm/> spec renders errors 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/CreateSender.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateSender.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateSender/> spec handles failed requests 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/CreateSenderForm.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/CreateSenderForm.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CreateSenderForm/> spec renders errors 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/DeleteRecipientGroupModal.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/DeleteRecipientGroupModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteRecipientGroupModal /> spec deletes recipient groups 1`] = `null`;
 

--- a/public/pages/Emails/__tests__/__snapshots__/DeleteSenderModal.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/DeleteSenderModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteSenderModal /> spec deletes senders 1`] = `null`;
 

--- a/public/pages/Emails/__tests__/__snapshots__/EmailGroups.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/EmailGroups.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EmailGroups/> spec renders the component 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/EmailSenders.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/EmailSenders.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EmailSenders/> spec renders the component with SMTP config type 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/RecipientGroupsTable.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<RecipientGroupsTable /> spec renders empty state 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTable.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SendersTable /> spec renders empty state 1`] = `
 <div

--- a/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
+++ b/public/pages/Emails/__tests__/__snapshots__/SendersTableControls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SendersTableControls /> spec renders the component 1`] = `
 <div

--- a/public/pages/Emails/__tests__/helper.test.ts
+++ b/public/pages/Emails/__tests__/helper.test.ts
@@ -82,8 +82,8 @@ describe('handles combo box create option', () => {
       setSelectedOptions,
       setInputError
     );
-    expect(setOptions).toBeCalledWith([...options, { label: 'new-option' }]);
-    expect(setSelectedOptions).toBeCalledWith([
+    expect(setOptions).toHaveBeenCalledWith([...options, { label: 'new-option' }]);
+    expect(setSelectedOptions).toHaveBeenCalledWith([
       ...selectedOptions,
       { label: 'new-option' },
     ]);
@@ -107,8 +107,8 @@ describe('handles combo box create option', () => {
       setSelectedOptions,
       setInputError
     );
-    expect(setOptions).not.toBeCalled();
-    expect(setSelectedOptions).toBeCalledWith([
+    expect(setOptions).not.toHaveBeenCalled();
+    expect(setSelectedOptions).toHaveBeenCalledWith([
       ...selectedOptions,
       { label: 'existing-option' },
     ]);

--- a/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
+++ b/public/pages/Main/__tests__/__snapshots__/Main.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Main /> spec renders the component 1`] = `
 <div

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -6,7 +6,7 @@
 module.exports = {
   rootDir: '../',
   setupFiles: ['<rootDir>/test/setupTests.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup.jest.ts'],
+  setupFilesAfterEnv: ['jest-location-mock', '<rootDir>/test/setup.jest.ts'],
   roots: ['<rootDir>'],
   testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
   clearMocks: true,
@@ -25,5 +25,16 @@ module.exports = {
     '\\.(css|less|sass|scss)$': '<rootDir>/test/mocks/styleMock.ts',
     '\\.(gif|ttf|eot|svg)$': '<rootDir>/test/mocks/fileMock.ts',
     '../../../src/core/server/utils': '<rootDir>/common/__tests__/mocks/workspaceStateMock.ts',
+  },
+  testEnvironmentOptions: {
+    // Set the default URL so window.location.origin is 'http://localhost:5601' rather than
+    // 'http://localhost', avoiding the need for tests to mock window.location.origin.
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
   },
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
     url: 'http://localhost:5601',
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -22,3 +22,22 @@ jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
     return () => 'random_html_id';
   },
 }));
+
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'
+// in all jsdom tests, consistent with the rest of the suite.
+process.env.HOST = 'http://localhost:5601';
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+['localStorage', 'sessionStorage'].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
+});


### PR DESCRIPTION
Closes #474

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `46 suites / 162 tests (159 passed, 3 skipped) / 82 snapshots passed`,
exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }` so `window.location.origin`
  is stable; added the `snapshotFormat: { escapeString: true, printBasicPrototype: true }`
  compatibility shim (Jest 29 flipped these defaults to `false`, which would otherwise invalidate
  existing snapshots).
- **Setup (`test/setup.jest.ts`):** set `process.env.HOST = 'http://localhost:5601'` (jest-location-mock
  uses `process.env.HOST` as the base URL for its `window.location` mock, keeping it consistent with
  `testEnvironmentOptions.url`); re-declared the non-configurable `localStorage`/`sessionStorage`
  properties as configurable (jsdom 26 marks them non-configurable) so individual tests can still
  override them via `Object.defineProperty` without hitting "Cannot redefine property" errors.
- **Matcher codemod:** `toBeCalled*` → `toHaveBeenCalled*` across 26 test files (Jest 30 removed the
  aliases). Affected suites include `Channels`, `CreateChannel`, and `Emails` page tests plus their
  `helper.test.ts` files.
- **Snapshots:** bumped the snapshot header URL (`goo.gl/fbAQLP` → `jestjs.io/docs/snapshot-testing`)
  across 37 `.snap` files — Jest 30 refuses to load the old header. Verified header-only: every
  changed `.snap` file has **zero** non-header content diffs, so no snapshots were regenerated and no
  serialization/content changes were introduced.

#### Plugin-specific changes
- None required. This plugin's tests needed no source-code fixes for jsdom 26 (no `window.location`
  reassignment, `window.URL`, fake-timer, ESM-dependency, enzyme-adapter, or async-query fixes were
  necessary). The migration for `dashboards-notifications` was limited to the shared config/setup
  adjustments, the matcher codemod, and the snapshot header bump above.

No `package.json` change needed — the plugin inherits the parent repo's Jest 30 stack (including
`jest-location-mock`).

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<this-plugin-issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
