### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check License Headers
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Check License Headers
+      - name: Add License Header
         run: npx @kt3k/license-checker

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,17 +1,5 @@
 {
-  "**/*.ts": [
-    " Copyright OpenSearch Contributors",
-    " SPDX-License-Identifier: Apache-2.0"
-  ],
-  "**/*.tsx": [
-    " Copyright OpenSearch Contributors",
-    " SPDX-License-Identifier: Apache-2.0"
-  ],
-  "**/*.js": [
-    " Copyright OpenSearch Contributors",
-    " SPDX-License-Identifier: Apache-2.0"
-  ],
-  "**/*.scss": [
+  "**/*.*": [
     " Copyright OpenSearch Contributors",
     " SPDX-License-Identifier: Apache-2.0"
   ],

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,43 @@
+{
+  "**/*.ts": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "**/*.tsx": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "**/*.js": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "**/*.scss": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".html",
+    ".config",
+    ".png",
+    ".svg",
+    ".ico",
+    ".lock",
+    ".snap",
+    ".git",
+    ".gitignore",
+    ".prettierrc",
+    ".prettierignore",
+    ".lintstagedrc",
+    "node_modules/",
+    "build/",
+    "dist/",
+    "target/",
+    "**/__snapshots__/",
+    "*.d.ts"
+  ]
+}

--- a/common/__tests__/mocks/workspaceStateMock.ts
+++ b/common/__tests__/mocks/workspaceStateMock.ts
@@ -1,1 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export const getWorkspaceState = jest.fn();

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export const BACKEND_CHANNEL_TYPE = Object.freeze({
   SLACK: 'slack',
   EMAIL: 'email',

--- a/public/components/MDSEnabledComponent/MDSEnabledComponent.tsx
+++ b/public/components/MDSEnabledComponent/MDSEnabledComponent.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React, { useContext, useEffect } from "react";
 import { DataSourceMenuContext, DataSourceMenuProperties } from "../../services/DataSourceMenuContext";
 import _ from 'lodash'

--- a/public/index.scss
+++ b/public/index.scss
@@ -1,0 +1,5 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+

--- a/public/services/DataSourceMenuContext.ts
+++ b/public/services/DataSourceMenuContext.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createContext } from "react";
 
 export interface DataSourceMenuProperties {

--- a/server/MDSEnabledClientService.ts
+++ b/server/MDSEnabledClientService.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 interface WorkspaceAuthorizer {
   authorizeWorkspace: (
     request: any,

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { PluginInitializerContext } from "../../../src/core/server";
 import { notificationsDashboardsPlugin } from "./plugin";
 

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   PluginInitializerContext,
   CoreSetup,

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface notificationsDashboardsPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
 [#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
